### PR TITLE
WIP add address property to streams and errors

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -17,14 +17,21 @@ function tail (opts) {
 }
 
 function compose (stream, transforms, cb) {
-  ;(function next (err, stream, i) {
-    if(err) return cb(err)
-    else if(i >= transforms.length) return cb(null, stream)
+  ;(function next (err, stream, i, addr) {
+    if(err) {
+      console.log(addr + '~' + err.address)
+      err.address = addr + '~' + err.address
+      return cb(err)
+    }
+    else if(i >= transforms.length) {
+      stream.address = addr
+      return cb(null, stream)
+    }
     else
       transforms[i](stream, function (err, stream) {
-        next(err, stream, i+1)
+        next(err, stream, i+1, err ? addr : addr+'~'+stream.address)
       })
-  })(null, stream, 0)
+  })(null, stream, 0, stream.address)
 }
 
 module.exports = function (ary) {
@@ -88,4 +95,8 @@ module.exports = function (ary) {
     }
   }
 }
+
+
+
+
 

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -5,13 +5,19 @@ try {
 
 var toPull = require('stream-to-pull-stream')
 
+function toDuplex (str) {
+  var stream = toPull.duplex(str)
+  stream.address = 'net:'+str.remoteAddress+':'+str.remotePort
+  return stream
+}
+
 module.exports = function (opts) {
   opts.allowHalfOpen = opts.allowHalfOpen !== false
   return {
     name: 'net',
     server: function (onConnection) {
       var server = net.createServer(opts, function (stream) {
-        onConnection(stream = toPull.duplex(stream))
+        onConnection(toDuplex(stream))
       }).listen(opts.port)
       return function () {
         server.close()
@@ -23,7 +29,8 @@ module.exports = function (opts) {
         .on('connect', function () {
           if(started) return
           started = true
-          cb(null, toPull.duplex(stream))
+
+          cb(null, toDuplex(stream))
         })
         .on('error', function (err) {
           if(started) return
@@ -50,4 +57,5 @@ module.exports = function (opts) {
     }
   }
 }
+
 

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -33,8 +33,10 @@ module.exports = function (opts) {
               }
               controlSocket = socket
 
-              socket.on('data', function(data) {
-                  onConnection(data = toPull.duplex(data))
+              socket.on('data', function(stream) {
+                  stream = toPull.duplex(stream)
+                  stream.address = 'onion:'
+                  onConnection(stream)
               })
 
               // Remember to resume the socket stream.

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -60,7 +60,10 @@ module.exports = function (opts) {
         socks.createConnection(connectOpts, function(err, socket) {
             if (err) return cb(err)
 
-            cb(null, toPull.duplex(socket))
+            var duplexStream = toPull.duplex(socket)
+            duplexStream.address = 'onion:'+connectOpts.target.host+':'+connectOpts.target.port
+
+            cb(null, duplexStream)
 
             // Remember to resume the socket stream.
             socket.resume()
@@ -85,8 +88,5 @@ module.exports = function (opts) {
     }
   }
 }
-
-
-
 
 

--- a/plugins/shs.js
+++ b/plugins/shs.js
@@ -20,9 +20,19 @@ module.exports = function (opts) {
     name: 'shs',
     create: function (_opts) {
       return function (stream, cb) {
+        function _cb (err, stream) {
+          if(err) {
+            //shs is designed so that we do not _know_ who is connecting if it fails,
+            //so we probably can't add the connecting address. (unless it was client unauthorized)
+            err.address = 'shs:'
+            return cb(err)
+          }
+          stream.address = 'shs:'+stream.remote.toString('base64')
+          cb(null, stream)
+        }
         pull(
           stream.source,
-          _opts && _opts.key ? client(_opts.key, _opts.seed, cb) : server(cb),
+          _opts && _opts.key ? client(_opts.key, _opts.seed, _cb) : server(_cb),
           stream.sink
         )
       }
@@ -50,6 +60,7 @@ module.exports = function (opts) {
     publicKey: keys && keys.publicKey
   }
 }
+
 
 
 

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -11,6 +11,7 @@ module.exports = function (opts) {
     server: function (onConnect) {
       if(!WS.createServer) return
       var server = WS.createServer(opts, function (stream) {
+        stream.address = 'ws:'+stream.remoteAddress + (stream.remotePort ? ':'+stream.remotePort : '')
         onConnect(stream)
       })
 
@@ -34,6 +35,7 @@ module.exports = function (opts) {
           cb(err, stream)
         }
       })
+      stream.address = addr
     },
     stringify: function () {
       if(!WS.createServer) return

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -95,6 +95,7 @@ tape('combined, ipv6', function (t) {
 
   combined.client(addr, function (err, stream) {
     if(err) throw err
+    t.ok(stream.address, 'has an address')
     pull(
       pull.values([new Buffer('hello world')]),
       stream,
@@ -110,10 +111,16 @@ tape('combined, ipv6', function (t) {
 
 
 tape('ws with combined', function (t) {
-  var close = combined_ws.server(echo)
+  var close = combined_ws.server(function (stream) {
+    console.log('combined_ws address', stream.address)
+    t.ok(stream.address, 'has an address')
+    echo(stream)
+  })
 
   combined_ws.client(combined_ws.stringify(), function (err, stream) {
     if(err) throw err
+    t.ok(stream.address, 'has an address')
+    console.log('combined_ws address', stream.address)
     var pushable = Pushable()
     pushable.push(new Buffer('hello world'))
     pull(


### PR DESCRIPTION
to solve https://github.com/ssbc/scuttlebot/issues/380 I think we may need to know where a connection is coming from. so, doing some work to put addresses on errors, and streams too because it feels like it should be there if it's on the error.

basically, the protocol plugin should add an address property to the stream that is called back, in the multiserver format. I don't expect that you can reconnect to that address, since it's probably just a client, but it's useful to know. I've added addresses for `net` and `shs`. we need `onion` and `ws`

@arj03 what information can a tor server get about the client? I'm guessing nothing? in which case the address should just be "onion:" i think.