### PR TITLE
remove console.log from compose

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -19,7 +19,6 @@ function tail (opts) {
 function compose (stream, transforms, cb) {
   ;(function next (err, stream, i, addr) {
     if(err) {
-      console.log(addr + '~' + err.address)
       err.address = addr + '~' + err.address
       return cb(err)
     }


### PR DESCRIPTION
looks like this was only here for debug purposes. It's causing unnecessary (and confusing) logging in sbot!