### PR TITLE
support multiple addresses from client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,28 @@ Multiserver makes it easy to use multiple protocols at once. For example,
 my pub server _also_ supports `shs` over websockets.
 
 So, this is another way to connect:
+
 ```
 wss://wx.larpa.net~shs:DTNmX+4SjsgZ7xyDh5xxmNtFqa6pWi5Qtw7cE8aR9TQ=
 ```
 
+if your server supports multiple protocols, you can concatenate addresses with `;`
+and multiserver will connect to the first address it understands.
+
+```
+net:wx.larpa.net:8008~shs:DTNmX+4SjsgZ7xyDh5xxmNtFqa6pWi5Qtw7cE8aR9TQ=;wss://wx.larpa.net~shs:DTNmX+4SjsgZ7xyDh5xxmNtFqa6pWi5Qtw7cE8aR9TQ=
+```
+This means use net, or wss. In some contexts, you might have a peer that understands
+websockets but not net (for example a browser), as long as a server speaks at least
+one protocol that a peer can understand, then they can communicate.
+
 ### net
 
-TCP is `net:{host}:{port}` port is not optional.
+TCP is a `net:{host}:{port}` port is not optional.
 
 ### ws
 
-WebSockets is `ws://{host}:{port}?` port defaults to 80 if not provided.
+WebSockets `ws://{host}:{port}?` port defaults to 80 if not provided.
 
 WebSockets over https is `wss://{host}:{port}?` where port is
 443 if not provided.
@@ -51,6 +62,24 @@ Secret-handshake is `shs:{public_key}:{seed}?`. `seed` is used to create
 a one-time shared private key, that may enable a special access.
 For example, you'll see that ssb invite codes have shs with two sections
 following. Normally, only a single argument (the remote public key) is necessary.
+
+### combined
+
+a network protocol is combined with 1 or more transform protocols,
+for example: `net:{host}:{port}~shs:{key}`
+
+### mutli
+
+A server that runs multiple protocols on different ports can simply join them
+with `;` and clients should connect to their preferred protocol.
+clients may try multiple protocols on the same server before giving up,
+but generally it's unlikely that protocols should not fail independently
+(unless there is a bug in one protocol).
+
+an example of a valid multiprotocol:
+`net:{host}:{port}~shs:{key};ws:{host}:{port}~shs:{key}`
+
+
 
 ### TODO
 

--- a/index.js
+++ b/index.js
@@ -14,12 +14,12 @@ module.exports = function (plugs, wrap) {
   return {
     name: plugs.map(function (e) { return e.name }).join(';'),
     client: function (addr, cb) {
-      var plug
-        split(addr).find(function (addr) {
+      var addr = split(addr).find(function (addr) {
         //connect with the first plug that understands this string.
         plug = plugs.find(function (plug) {
-          return plug.parse(addr)
+          return plug.parse(addr) ? plug : null
         })
+        if(plug) return addr
       })
       if(plug) plug.client(addr, cb)
       else cb(new Error('could not connect to one of:'+addr))
@@ -49,5 +49,4 @@ module.exports = function (plugs, wrap) {
     }
   }
 }
-
 

--- a/test/multi.js
+++ b/test/multi.js
@@ -1,0 +1,117 @@
+var tape = require('tape')
+var pull = require('pull-stream')
+var Pushable = require('pull-pushable')
+
+var Compose = require('../compose')
+var Net = require('../plugins/net')
+var Ws = require('../plugins/ws')
+var Shs = require('../plugins/shs')
+var Onion = require('../plugins/onion')
+var MultiServer = require('../')
+
+var cl = require('chloride')
+var seed = cl.crypto_hash_sha256(new Buffer('TESTSEED'))
+var keys = cl.crypto_sign_seed_keypair(seed)
+var appKey = cl.crypto_hash_sha256(new Buffer('TEST'))
+
+var requested, ts
+
+//this gets overwritten in the last test.
+var check = function (id, cb) {
+  cb(null, true)
+}
+
+var net = Net({port: 4848})
+var ws = Ws({port: 4849})
+var shs = Shs({keys: keys, appKey: appKey, auth: function (id, cb) {
+  requested = id
+  ts = Date.now()
+
+  check(id, cb)
+}})
+
+var combined = Compose([net, shs])
+var combined_ws = Compose([ws, shs])
+
+var multi = MultiServer([
+  combined, combined_ws
+])
+
+var multi_ws = MultiServer([ combined_ws ])
+var multi_net = MultiServer([ combined ])
+
+var client_addr
+
+var close = multi.server(function (stream) {
+  console.log("onConnect", stream.address)
+  client_addr = stream.address
+  pull(stream, stream)
+})
+
+var server_addr =
+'fake:peer.ignore~nul:what;'+multi.stringify()
+//"fake" in a unkown protocol, just to make sure it gets skipped.
+
+tape('connect to either server', function (t) {
+
+  multi.client(server_addr, function (err, stream) {
+    if(err) throw err
+    console.log(stream)
+    t.ok(/^net/.test(client_addr), 'client connected via net')
+    t.ok(/^net/.test(stream.address), 'client connected via net')
+    pull(
+      pull.values([new Buffer('Hello')]),
+      stream,
+      pull.collect(function (err,  ary) {
+        var data = Buffer.concat(ary).toString('utf8')
+        console.log("OUTPUT", data)
+//        close()
+        t.end()
+      })
+    )
+  })
+})
+
+tape('connect to either server', function (t) {
+
+  console.log(multi.stringify())
+
+  multi_ws.client(server_addr, function (err, stream) {
+    if(err) throw err
+    t.ok(/^ws/.test(client_addr), 'client connected via ws')
+    t.ok(/^ws/.test(stream.address), 'client connected via net')
+    pull(
+      pull.values([new Buffer('Hello')]),
+      stream,
+      pull.collect(function (err,  ary) {
+        var data = Buffer.concat(ary).toString('utf8')
+        console.log("OUTPUT", data)
+        t.end()
+      })
+    )
+  })
+})
+
+tape('connect to either server', function (t) {
+
+  multi_net.client(server_addr, function (err, stream) {
+    if(err) throw err
+    t.ok(/^net/.test(client_addr), 'client connected via net')
+    t.ok(/^net/.test(stream.address), 'client connected via net')
+    pull(
+      pull.values([new Buffer('Hello')]),
+      stream,
+      pull.collect(function (err,  ary) {
+        var data = Buffer.concat(ary).toString('utf8')
+        console.log("OUTPUT", data)
+        t.end()
+      })
+    )
+  })
+})
+
+tape('close', function (t) {
+  close()
+  t.end()
+})
+


### PR DESCRIPTION
this adds previously incomplete support for handling multiple addresses from the client side. you just pass a list of addresses separated by `;` and the client connects to the first address that it understands.

this is useful for implementing better pub advertisments,
`%/42EUaUk51JUbiq3zphfImWRN9CZ7CyQ2Za5xrhORss=.sha256`

this will also be very useful for utp and webrtc @pietgeursen @staltz @arj03 
