### PR TITLE
scoped transformations

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -88,10 +88,10 @@ module.exports = function (ary, wrap) {
       })
     },
     parse: parse,
-    stringify: function () {
+    stringify: function (scope) {
       var none
       var _ary = ary.map(function (e) {
-        var v = e.stringify()
+        var v = e.stringify(scope)
         if(!v) none = true
         else return v
       })

--- a/compose.js
+++ b/compose.js
@@ -58,6 +58,7 @@ module.exports = function (ary, wrap) {
 
   return {
     name: ary.map(function (e) { return e.name }).join(separator),
+    scope: proto.scope,
     client: function (_opts, cb) {
       var opts = parseMaybe(_opts)
       if(!opts) return cb(new Error('could not parse address:'+_opts))

--- a/index.js
+++ b/index.js
@@ -37,8 +37,8 @@ module.exports = function (plugs, wrap) {
     stringify: function (scope) {
       if (!scope) scope = 'public'
       return plugs.map(function (plug) {
-        if (plug.scope() == scope)
-          return plug.stringify()
+        if (plug.scope() == scope || (plug.scope() == 'public' && scope == 'private'))
+          return plug.stringify(scope)
       }).filter(Boolean).join(';')
     },
     //parse doesn't really make sense here...

--- a/index.js
+++ b/index.js
@@ -34,9 +34,11 @@ module.exports = function (plugs, wrap) {
         closes.forEach(function (close) { close() })
       }
     },
-    stringify: function () {
+    stringify: function (scope) {
+      if (!scope) scope = 'public'
       return plugs.map(function (plug) {
-        return plug.stringify()
+        if (plug.scope() == scope)
+          return plug.stringify()
       }).filter(Boolean).join(';')
     },
     //parse doesn't really make sense here...

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "secret-handshake": "^1.1.12",
     "separator-escape": "0.0.0",
     "socks": "1.1.9",
+    "ssb-config": "^2.2.0",
     "stream-to-pull-stream": "^1.7.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "secret-handshake": "^1.1.12",
     "separator-escape": "0.0.0",
     "socks": "1.1.9",
-    "ssb-config": "^2.2.0",
     "stream-to-pull-stream": "^1.7.2"
   },
   "devDependencies": {

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -62,8 +62,11 @@ module.exports = function (opts) {
         port: port
       }
     },
-    stringify: function () {
-      return ['net', opts.external || opts.host || 'localhost', opts.port].join(':')
+    stringify: function (scope) {
+      var host = opts.external || opts.host || 'localhost'
+      if (scope == 'private')
+        host = opts.host || 'localhost'
+      return ['net', host, opts.port].join(':')
     }
   }
 }

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -12,9 +12,11 @@ function toDuplex (str) {
 }
 
 module.exports = function (opts) {
+  // FIXME: does this even work anymore?
   opts.allowHalfOpen = opts.allowHalfOpen !== false
   return {
     name: 'net',
+    scope: function() { return opts.scope },
     server: function (onConnection) {
       var server = net.createServer(opts, function (stream) {
         var addr = stream.address()
@@ -61,8 +63,7 @@ module.exports = function (opts) {
       }
     },
     stringify: function () {
-      return ['net', opts.host || 'localhost', opts.port].join(':')
+      return ['net', opts.external || opts.host || 'localhost', opts.port].join(':')
     }
   }
 }
-

--- a/plugins/noauth.js
+++ b/plugins/noauth.js
@@ -5,12 +5,12 @@ module.exports = function (opts) {
     name: 'noauth',
     create: function (_opts) {
       return function (stream, cb) {
-        stream.address = 'noauth'
         cb(null, {
-          remote: '',
+          remote: opts.keys.publicKey,
           auth: { allow: null, deny: null },
           source: stream.source,
-          sink: stream.sink
+          sink: stream.sink,
+          address: 'noauth:' + opts.keys.publicKey.toString('base64')
         })
       }
     },
@@ -22,8 +22,3 @@ module.exports = function (opts) {
     }
   }
 }
-
-
-
-
-

--- a/plugins/noauth.js
+++ b/plugins/noauth.js
@@ -1,0 +1,29 @@
+var pull = require('pull-stream')
+
+module.exports = function (opts) {
+  return {
+    name: 'noauth',
+    create: function (_opts) {
+      return function (stream, cb) {
+        stream.address = 'noauth'
+        cb(null, {
+          remote: '',
+          auth: { allow: null, deny: null },
+          source: stream.source,
+          sink: stream.sink
+        })
+      }
+    },
+    parse: function (str) {
+      return {}
+    },
+    stringify: function () {
+      return 'noauth'
+    }
+  }
+}
+
+
+
+
+

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -13,6 +13,7 @@ module.exports = function (opts) {
   }
   return {
     name: 'onion',
+    scope: function() { return opts.scope },
     server: function (onConnection) {
           if(!opts.server) return
 

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -11,14 +11,6 @@ module.exports = function (opts) {
   const socket = path.join(config.path, 'socket')
   const addr = 'unix:' + socket
   
-  function toDuplex (str) {
-    var stream = toPull.duplex(str)
-    stream.address = addr
-    stream.remote = 'unix'
-    stream.auth = { allow: null, deny: null }
-    return stream
-  }
-
   opts = opts || {}
   return {
     name: 'unix',
@@ -28,7 +20,7 @@ module.exports = function (opts) {
       console.log("listening on socket")
 
       var server = net.createServer(opts, function (stream) {
-        onConnection(toDuplex(stream))
+        onConnection(toPull.duplex(stream))
       }).listen(socket)
 
       server.on('error', function (e) {
@@ -63,7 +55,7 @@ module.exports = function (opts) {
           if(started) return
           started = true
 
-          cb(null, toDuplex(stream))
+          cb(null, toPull.duplex(stream))
         })
         .on('error', function (err) {
           console.log("err?", err)

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -1,0 +1,97 @@
+var toPull = require('stream-to-pull-stream')
+var net = require('net')
+var fs = require('fs')
+var path = require('path')
+
+// hax on double transform
+var started = false
+
+module.exports = function (opts) {
+  const config = require('ssb-config/inject')(process.env.ssb_appname)
+  const socket = path.join(config.path, 'socket')
+  const addr = 'local:' + socket
+  
+  function toDuplex (str) {
+    var stream = toPull.duplex(str)
+    stream.address = addr
+    stream.remote = 'local'
+    stream.auth = { allow: null, deny: null }
+    return stream
+  }
+
+  opts = opts || {}
+  return {
+    name: 'local',
+    scope: function() { return opts.scope },
+    server: function (onConnection) {
+      if(started) return
+      console.log("listening on socket")
+
+      var server = net.createServer(opts, function (stream) {
+        onConnection(toDuplex(stream))
+      }).listen(socket)
+
+      server.on('error', function (e) {
+        if (e.code == 'EADDRINUSE') {
+          var clientSocket = new net.Socket()
+          clientSocket.on('error', function(e) {
+            if (e.code == 'ECONNREFUSED') { 
+              fs.unlinkSync(socket)
+              server.listen(socket)
+            }
+          })
+          
+          clientSocket.connect({ path: socket }, function() { 
+            console.log("someone else is listening on socket!")
+          })
+        }
+      })
+      
+      fs.chmodSync(socket, 0600)
+
+      started = true
+      
+      return function () {
+        server.close()
+      }
+    },
+    client: function (opts, cb) {
+      console.log("local socket client")
+      var started = false
+      var stream = net.connect(opts)
+        .on('connect', function () {
+          if(started) return
+          started = true
+
+          cb(null, toDuplex(stream))
+        })
+        .on('error', function (err) {
+          console.log("err?", err)
+          if(started) return
+          started = true
+          cb(err)
+        })
+
+      return function () {
+        started = true
+        stream.destroy()
+        cb(new Error('multiserver.local: aborted'))
+      }
+    },
+    //MUST be local:socket_path
+    parse: function (s) {
+      var ary = s.split(':')
+      if(ary.length < 2) return null
+      if('local' !== ary.shift()) return null
+      return {
+        name: '',
+        path: ary.shift()
+      }
+    },
+    stringify: function () {
+      if(opts && !opts.server) return
+      return ['local', opts.path].join(':')
+    }
+  }
+}
+

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -82,7 +82,7 @@ module.exports = function (opts) {
     parse: function (s) {
       var ary = s.split(':')
       if(ary.length < 2) return null
-      if('local' !== ary.shift()) return null
+      if('unix' !== ary.shift()) return null
       return {
         name: '',
         path: ary.shift()

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -7,8 +7,7 @@ var path = require('path')
 var started = false
 
 module.exports = function (opts) {
-  const config = require('ssb-config/inject')(process.env.ssb_appname)
-  const socket = path.join(config.path, 'socket')
+  const socket = path.join(opts.path || '', 'socket')
   const addr = 'unix:' + socket
   
   opts = opts || {}
@@ -17,7 +16,7 @@ module.exports = function (opts) {
     scope: function() { return opts.scope },
     server: function (onConnection) {
       if(started) return
-      console.log("listening on socket")
+      console.log("listening on socket", addr)
 
       var server = net.createServer(opts, function (stream) {
         onConnection(toPull.duplex(stream))

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -9,19 +9,19 @@ var started = false
 module.exports = function (opts) {
   const config = require('ssb-config/inject')(process.env.ssb_appname)
   const socket = path.join(config.path, 'socket')
-  const addr = 'local:' + socket
+  const addr = 'unix:' + socket
   
   function toDuplex (str) {
     var stream = toPull.duplex(str)
     stream.address = addr
-    stream.remote = 'local'
+    stream.remote = 'unix'
     stream.auth = { allow: null, deny: null }
     return stream
   }
 
   opts = opts || {}
   return {
-    name: 'local',
+    name: 'unix',
     scope: function() { return opts.scope },
     server: function (onConnection) {
       if(started) return
@@ -56,7 +56,7 @@ module.exports = function (opts) {
       }
     },
     client: function (opts, cb) {
-      console.log("local socket client")
+      console.log("unix socket client")
       var started = false
       var stream = net.connect(opts)
         .on('connect', function () {
@@ -75,10 +75,10 @@ module.exports = function (opts) {
       return function () {
         started = true
         stream.destroy()
-        cb(new Error('multiserver.local: aborted'))
+        cb(new Error('multiserver.unix: aborted'))
       }
     },
-    //MUST be local:socket_path
+    //MUST be unix:socket_path
     parse: function (s) {
       var ary = s.split(':')
       if(ary.length < 2) return null

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -9,6 +9,7 @@ module.exports = function (opts) {
   var secure = opts.server && !!opts.server.key
   return {
     name: 'ws',
+    scope: function() { return opts.scope },
     server: function (onConnect) {
       if(!WS.createServer) return
       var server = WS.createServer(opts, function (stream) {

--- a/test/multi.js
+++ b/test/multi.js
@@ -21,8 +21,8 @@ var check = function (id, cb) {
   cb(null, true)
 }
 
-var net = Net({port: 4848})
-var ws = Ws({port: 4849})
+var net = Net({port: 4848, scope: 'public'})
+var ws = Ws({port: 4849, scope: 'public'})
 var shs = Shs({keys: keys, appKey: appKey, auth: function (id, cb) {
   requested = id
   ts = Date.now()


### PR DESCRIPTION
This is the first in a series of changes across the ssb stack. Pending changes to ssb-client and secret-stack (which is then needed for sbot) depend on this.

This adds scoping so that _invites can use the public one_, for instance.

This also adds two plugins:
* pass-through style `noauth` transform.
* unix-socket/named pipe transport

See for more https://github.com/ssbc/secret-stack/pull/21#issuecomment-407880466 - @arj and I tested all of this last weekend in person during `%27rdEuNneOwaXtG7N8mA/LCFMWEy7SgSbvboWw74vGw=.sha256`.