### PR TITLE
Travis and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+sudo: false
 node_js:
-  - 0.6
-  - 0.8
+  - 8
+  - 6
+  - 10

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pull-ws": "^3.3.0",
     "secret-handshake": "^1.1.12",
     "separator-escape": "0.0.0",
-    "socks": "1.1.9",
+    "socks": "2.2.1",
     "stream-to-pull-stream": "^1.7.2"
   },
   "devDependencies": {

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -2,7 +2,10 @@ var socks = require('socks');
 var toPull = require('stream-to-pull-stream')
 
 module.exports = function (opts) {
-  if(!socks) return //we are in browser
+  if(!socks) { //we are in browser
+	console.warn('onion dialing through socks proxy not supported in browser setting')
+	return 
+  }
 
   opts = opts || {}
   var proxyOpts = {
@@ -28,7 +31,7 @@ module.exports = function (opts) {
           socks.createConnection(serverOpts, function (err, socket) {
               if(err) {
                 console.error('unable to find local tor server.')
-                console.error('will be able receive tor connections')
+				console.error('will be able receive tor connections') // << ???
                 return
               }
               controlSocket = socket


### PR DESCRIPTION
I thought we might want to get testing in order before doing #14 but I ran into this:


```
# error should have client address on it
server error, from ws:::ffff:127.0.0.1~shs:
Error: stream ended with:0 but wanted:64
    at drain (/home/cryptix/ssb/multiserver/node_modules/pull-reader/index.js:43:26)
    at /home/cryptix/ssb/multiserver/node_modules/pull-reader/index.js:63:18
    at /home/cryptix/ssb/multiserver/node_modules/pull-reader/index.js:20:7
    at WebSocket.<anonymous> (/home/cryptix/ssb/multiserver/node_modules/pull-ws/source.js:40:7)
    at WebSocket.onClose (/home/cryptix/ssb/multiserver/node_modules/ws/lib/WebSocket.js:446:14)
    at emitTwo (events.js:131:20)
    at WebSocket.emit (events.js:214:7)
    at WebSocket.cleanupWebsocketResources (/home/cryptix/ssb/multiserver/node_modules/ws/lib/WebSocket.js:950:8)
    at emitNone (events.js:111:20)
    at Socket.emit (events.js:208:7)
/home/cryptix/ssb/multiserver/node_modules/sodium-chloride/index.js:126
    na.crypto_sign_ed25519_pk_to_curve25519(curve_pk, ed_pk)
       ^

Error: EEXIST, File exists
    at exports.crypto_sign_ed25519_pk_to_curve25519 (/home/cryptix/ssb/multiserver/node_modules/sodium-chloride/index.js:126:8)
    at Object.exports.clientVerifyChallenge (/home/cryptix/ssb/multiserver/node_modules/secret-handshake/crypto.js:119:41)
    at Object.cb (/home/cryptix/ssb/multiserver/node_modules/secret-handshake/protocol.js:44:32)
    at drain (/home/cryptix/ssb/multiserver/node_modules/pull-reader/index.js:39:14)
    at more (/home/cryptix/ssb/multiserver/node_modules/pull-reader/index.js:55:13)
    at /home/cryptix/ssb/multiserver/node_modules/pull-reader/index.js:66:9
    at /home/cryptix/ssb/multiserver/node_modules/pull-reader/index.js:20:7
    at drain (/home/cryptix/ssb/multiserver/node_modules/stream-to-pull-stream/index.js:141:18)
    at Socket.<anonymous> (/home/cryptix/ssb/multiserver/node_modules/stream-to-pull-stream/index.js:150:5)
    at emitOne (events.js:116:13)
npm ERR! Test failed.  See above for more details.
```

not sure if my environment has something to do with this which is why I updated the travis file.

also noticed that the socks5 dependency was obsolete