### PR TITLE
plugins should never have undefined scopes

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,10 +36,14 @@ module.exports = function (plugs, wrap) {
     },
     stringify: function (scope) {
       if (!scope) scope = 'public'
-      return plugs.map(function (plug) {
-        if (plug.scope() == scope || (plug.scope() == 'public' && scope == 'private'))
-          return plug.stringify(scope)
-      }).filter(Boolean).join(';')
+      return plugs
+        .filter(function (plug) {
+          return plug.scope() === scope ||
+            (plug.scope() === 'public' && scope === 'private')
+        })
+        .map(function (plug) { return plug.stringify(scope) })
+        .filter(Boolean)
+        .join(';')
     },
     //parse doesn't really make sense here...
     //like, what if you only have a partial match?

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -16,7 +16,7 @@ module.exports = function (opts) {
   opts.allowHalfOpen = opts.allowHalfOpen !== false
   return {
     name: 'net',
-    scope: function() { return opts.scope },
+    scope: function() { return opts.scope || 'public' },
     server: function (onConnection) {
       var server = net.createServer(opts, function (stream) {
         var addr = stream.address()
@@ -64,7 +64,7 @@ module.exports = function (opts) {
     },
     stringify: function (scope) {
       var host = opts.external || opts.host || 'localhost'
-      if (scope == 'private')
+      if (scope === 'private')
         host = opts.host || 'localhost'
       return ['net', host, opts.port].join(':')
     }

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -4,7 +4,7 @@ var toPull = require('stream-to-pull-stream')
 module.exports = function (opts) {
   if(!socks) { //we are in browser
     console.warn('onion dialing through socks proxy not supported in browser setting')
-    return 
+    return
   }
 
   opts = opts || {}
@@ -16,7 +16,7 @@ module.exports = function (opts) {
   }
   return {
     name: 'onion',
-    scope: function() { return opts.scope },
+    scope: function() { return opts.scope || 'public' },
     server: function (onConnection) {
       if(!opts.server) return
 

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -9,11 +9,11 @@ var started = false
 module.exports = function (opts) {
   const socket = path.join(opts.path || '', 'socket')
   const addr = 'unix:' + socket
-  
+
   opts = opts || {}
   return {
     name: 'unix',
-    scope: function() { return opts.scope },
+    scope: function() { return opts.scope || 'public' },
     server: function (onConnection) {
       if(started) return
       console.log("listening on socket", addr)
@@ -26,22 +26,22 @@ module.exports = function (opts) {
         if (e.code == 'EADDRINUSE') {
           var clientSocket = new net.Socket()
           clientSocket.on('error', function(e) {
-            if (e.code == 'ECONNREFUSED') { 
+            if (e.code == 'ECONNREFUSED') {
               fs.unlinkSync(socket)
               server.listen(socket)
             }
           })
-          
-          clientSocket.connect({ path: socket }, function() { 
+
+          clientSocket.connect({ path: socket }, function() {
             console.log("someone else is listening on socket!")
           })
         }
       })
-      
+
       fs.chmodSync(socket, 0600)
 
       started = true
-      
+
       return function () {
         server.close()
       }

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -9,7 +9,7 @@ module.exports = function (opts) {
   var secure = opts.server && !!opts.server.key
   return {
     name: 'ws',
-    scope: function() { return opts.scope },
+    scope: function() { return opts.scope || 'public' },
     server: function (onConnect) {
       if(!WS.createServer) return
       var server = WS.createServer(opts, function (stream) {


### PR DESCRIPTION
Now that we added scopes, plugins need a default scope otherwise they wouldn't stringify. Has led to more serious bugs upwards in the SSB stack. I'll merge soon because this is a hotfix.