### PR TITLE
Bind servers to specific address instead of all addresses

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -86,7 +86,7 @@ module.exports = function (ary, wrap) {
       })
     },
     // There should be a callback , called with
-    // null when the server startsed to listen
+    // null when the server started to listen.
     // (net.server.listen is async for example)
     server: function (onConnection, onError) {
       onError = onError || function (err) {

--- a/compose.js
+++ b/compose.js
@@ -36,6 +36,20 @@ function compose (stream, transforms, cb) {
   })(null, stream, 0, stream.address)
 }
 
+function asyncify(f) {
+  return function(cb) {
+    if (f.length) return f(cb)
+    if (cb) {
+      var result
+      try{
+        result = f()
+      } catch(err) {return cb(err)}
+      return cb(null, result)
+    }
+    return f()
+  }
+}
+
 module.exports = function (ary, wrap) {
   if(!wrap) wrap = function (e) { return e }
   var proto = head(ary)
@@ -71,12 +85,15 @@ module.exports = function (ary, wrap) {
         )
       })
     },
+    // There should be a callback , called with
+    // null when the server startsed to listen
+    // (net.server.listen is async for example)
     server: function (onConnection, onError) {
       onError = onError || function (err) {
         console.error('server error, from', err.address)
         console.error(err.stack)
       }
-      return proto.server(function (stream) {
+      return asyncify(proto.server(function (stream) {
         compose(
           wrap(stream),
           trans.map(function (tr) { return tr.create() }),
@@ -85,7 +102,7 @@ module.exports = function (ary, wrap) {
             else onConnection(stream)
           }
         )
-      })
+      }))
     },
     parse: parse,
     stringify: function (scope) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "secret-handshake": "^1.1.12",
     "separator-escape": "0.0.0",
     "socks": "2.2.1",
-    "ssb-scopes": "^1.0.0",
+    "multiserver-scopes": "^1.0.0",
     "stream-to-pull-stream": "^1.7.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/dominictarr/multiserver.git"
   },
   "dependencies": {
+    "multicb": "^1.2.2",
     "pull-cat": "~1.1.5",
     "pull-stream": "^3.6.1",
     "pull-ws": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "secret-handshake": "^1.1.12",
     "separator-escape": "0.0.0",
     "socks": "2.2.1",
+    "ssb-scopes": "^1.0.0",
     "stream-to-pull-stream": "^1.7.2"
   },
   "devDependencies": {

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -26,9 +26,13 @@ module.exports = function (opts) {
         var addr = stream.address()
         onConnection(toDuplex(stream))
       }).listen(port, host)
-      return function () {
-        console.log('No longer listening on ' + host + ':' + port + ' (multiserver net plugin)')
-        server.close()
+      return function (cb) {
+        console.log('Closing server on ' + host + ':' + port + ' (multiserver net plugin)')
+        server.close(function(err) {
+          if (err) console.error(err)
+          else console.log('No longer listening on ' + host + ':' + port + ' (multiserver net plugin)')
+          if (cb) cb(err) 
+        })
       }
     },
     client: function (opts, cb) {

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -4,7 +4,7 @@ try {
 } catch (_) {}
 
 var toPull = require('stream-to-pull-stream')
-var scopes = require('ssb-scopes')
+var scopes = require('multiserver-scopes')
 
 function toDuplex (str) {
   var stream = toPull.duplex(str)

--- a/plugins/shs.js
+++ b/plugins/shs.js
@@ -7,7 +7,7 @@ function isString(s) {
 
 module.exports = function (opts) {
   var keys = SHS.toKeys(opts.keys || opts.seed)
-  var appKey = isString(opts.appKey) ? new Buffer(opts.appKey, 'base64') : opts.appKey
+  var appKey = isString(opts.appKey) ? Buffer.from(opts.appKey, 'base64') : opts.appKey
 
   var server = SHS.createServer(
     keys, opts.auth || opts.authenticate, appKey, opts.timeout
@@ -45,10 +45,10 @@ module.exports = function (opts) {
       //seed of private key to connect with, optional.
 
       if(ary.length > 2) {
-        seed = new Buffer(ary[2], 'base64')
+        seed = Buffer.from(ary[2], 'base64')
         if(seed.length !== 32) return null
       }
-      var key = new Buffer(ary[1], 'base64')
+      var key = Buffer.from(ary[1], 'base64')
       if(key.length !== 32) return null
 
       return {key: key, seed: seed}

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -2,7 +2,7 @@ var WS = require('pull-ws')
 var URL = require('url')
 var pull = require('pull-stream/pull')
 var Map = require('pull-stream/throughs/map')
-var scopes = require('ssb-scopes')
+var scopes = require('multiserver-scopes')
 
 module.exports = function (opts) {
   opts = opts || {}

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -23,9 +23,13 @@ module.exports = function (opts) {
         console.log('Listening on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')
         server.listen(opts.port)
       }
-      return function() {
-        console.log('No longer listening on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')
-        server.close()
+      return function (cb) {
+        console.log('Closing server on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')
+        server.close(function(err) {
+          if (err) console.error(err)
+          else console.log('No longer listening on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')
+          if (cb) cb(err) 
+        })
       }
     },
     client: function (addr, cb) {

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -2,6 +2,7 @@ var WS = require('pull-ws')
 var URL = require('url')
 var pull = require('pull-stream/pull')
 var Map = require('pull-stream/throughs/map')
+var scopes = require('ssb-scopes')
 
 module.exports = function (opts) {
   opts = opts || {}
@@ -12,13 +13,20 @@ module.exports = function (opts) {
     scope: function() { return opts.scope || 'public' },
     server: function (onConnect) {
       if(!WS.createServer) return
+      opts.host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
       var server = WS.createServer(opts, function (stream) {
         stream.address = 'ws:'+stream.remoteAddress + (stream.remotePort ? ':'+stream.remotePort : '')
         onConnect(stream)
       })
 
-      if(!opts.server) server.listen(opts.port)
-      return server.close.bind(server)
+      if(!opts.server) {
+        console.log('Listening on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')
+        server.listen(opts.port)
+      }
+      return function() {
+        console.log('No longer listening on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')
+        server.close()
+      }
     },
     client: function (addr, cb) {
       if(!addr.host) {
@@ -33,7 +41,7 @@ module.exports = function (opts) {
         binaryType: opts.binaryType,
         onConnect: function (err) {
           //ensure stream is a stream of node buffers
-          stream.source = pull(stream.source, Map(Buffer))
+          stream.source = pull(stream.source, Map(Buffer.from.bind(Buffer)))
           cb(err, stream)
         }
       })

--- a/test/async-server-close.js
+++ b/test/async-server-close.js
@@ -1,0 +1,87 @@
+var test = require('tape')
+var Ms = require('../')
+
+function sync_server(t) {
+  return {
+    server: function() {
+      return function close() {
+        t.pass('sync close')
+      }
+    }
+  }
+}
+
+function async_server(t) {
+  return {
+    server: function() {
+      return function close(cb) {
+        setTimeout(function() {
+          t.comment('async close')
+          t.async_calls = (t.async_calls || 0) + 1
+          cb(null)
+        }, 100)
+      }
+    }
+  }
+}
+
+test('all calls are sync', function(t) {
+  var ms = Ms([
+    sync_server(t),
+    sync_server(t)
+  ])
+  var close = ms.server()
+  t.plan(2)
+  close()
+})
+
+test('all calls are async', function(t) {
+  var ms = Ms([
+    async_server(t),
+    async_server(t)
+  ])
+  var close = ms.server()
+  close(function(err) {
+    t.error(err)
+    t.equal(t.async_calls, 2, 'Should have waited for both servers')
+    t.end()
+  })
+})
+
+test.only('async caller, sync callee', function(t) {
+  var ms = Ms([
+    sync_server(t),
+    sync_server(t)
+  ])
+  var close = ms.server()
+  close(function(err) {
+    t.error(err)
+    t.end()
+  })
+})
+
+test('all calls are async', function(t) {
+  var ms = Ms([
+    async_server(t),
+    async_server(t)
+  ])
+  var close = ms.server()
+  close(function(err) {
+    t.error(err)
+    t.equal(t.async_calls, 2, 'Should have waited for both servers')
+    t.end()
+  })
+})
+
+test('async caller, mixed callees', function(t) {
+  var ms = Ms([
+    sync_server(t),
+    async_server(t)
+  ])
+  var close = ms.server()
+  t.plan(3)
+  close(function(err) {
+    t.error(err)
+    t.equal(t.async_calls, 1, 'Should have waited for async servers')
+  })
+})

--- a/test/multi.js
+++ b/test/multi.js
@@ -10,9 +10,9 @@ var Onion = require('../plugins/onion')
 var MultiServer = require('../')
 
 var cl = require('chloride')
-var seed = cl.crypto_hash_sha256(new Buffer('TESTSEED'))
+var seed = cl.crypto_hash_sha256(Buffer.from('TESTSEED'))
 var keys = cl.crypto_sign_seed_keypair(seed)
-var appKey = cl.crypto_hash_sha256(new Buffer('TEST'))
+var appKey = cl.crypto_hash_sha256(Buffer.from('TEST'))
 
 var requested, ts
 
@@ -60,7 +60,7 @@ tape('connect to either server', function (t) {
     t.ok(/^net/.test(client_addr), 'client connected via net')
     t.ok(/^net/.test(stream.address), 'client connected via net')
     pull(
-      pull.values([new Buffer('Hello')]),
+      pull.values([Buffer.from('Hello')]),
       stream,
       pull.collect(function (err,  ary) {
         var data = Buffer.concat(ary).toString('utf8')
@@ -81,7 +81,7 @@ tape('connect to either server', function (t) {
     t.ok(/^ws/.test(client_addr), 'client connected via ws')
     t.ok(/^ws/.test(stream.address), 'client connected via net')
     pull(
-      pull.values([new Buffer('Hello')]),
+      pull.values([Buffer.from('Hello')]),
       stream,
       pull.collect(function (err,  ary) {
         var data = Buffer.concat(ary).toString('utf8')
@@ -99,7 +99,7 @@ tape('connect to either server', function (t) {
     t.ok(/^net/.test(client_addr), 'client connected via net')
     t.ok(/^net/.test(stream.address), 'client connected via net')
     pull(
-      pull.values([new Buffer('Hello')]),
+      pull.values([Buffer.from('Hello')]),
       stream,
       pull.collect(function (err,  ary) {
         var data = Buffer.concat(ary).toString('utf8')

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -35,6 +35,9 @@ var shs = Shs({keys: keys, appKey: appKey, auth: function (id, cb) {
 var combined = Compose([net, shs])
 var combined_ws = Compose([ws, shs])
 
+// travis currently does not support ipv6, becaue GCE does not.
+var has_ipv6 = process.env.TRAVIS === undefined
+
 tape('parse, stringify', function (t) {
 
   t.equal(
@@ -94,7 +97,7 @@ tape('combined', function (t) {
   })
 })
 
-
+if (has_ipv6)
 tape('combined, ipv6', function (t) {
   var combined = Compose([
     Net({

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -1,7 +1,7 @@
 var tape = require('tape')
 var pull = require('pull-stream')
 var Pushable = require('pull-pushable')
-var scopes = require('ssb-scopes')
+var scopes = require('multiserver-scopes')
 
 var Compose = require('../compose')
 var Net = require('../plugins/net')


### PR DESCRIPTION
Currently we listen for tcp connections on all available IP
addresses (by callsing `server.listen(port, host)`
with just one parameter. As a consequence, the `host` option in `config.connections.incoming` (and, indirectly, `config.host`) is currently ignored.

This is not only unexpected, but also dangerous when the noauth transform is used in combination with the net transport. Users are not aware that noauth will also be available on public IP addresses, even when they explicity set `host` to 'localhost' or `scope` to `device`, `local` or private, all of which is currently ignored.

This PR fixes these problems by using the host/IP given in `opts.host` to bind the server socket to if that is undefind, it picks a default host that is within `opts.scope`. If neither `opts.host` nor `opts.scope` is given, it defaults to `localhost`. To bind to all available interfaces, you now have to explicitly set `opts.host` to `::`. (The default should be safe)

This breaks backwards compatibility, but I think it's the right thing to do in this case. One invite test in scuttlebot needs to be adapted, because it expects sbot to bind to all interfaces by default.

(this could be fixed by adding `host: '::'` to the default incomings created in secret-stack and ssb-config)

The same mechanism is in place for the ws transport. However, debug output shows that this plugin is never used outside tests. (ws is handled by ssb-ws)

I left the log output in place, because I think it's super useful for the user to see what ports/hosts the server is listening on.

This also removes use of `Buffer()` (deprecated) and fixes potential problems with test not waiting for the servers they created to properly shutdown before moving on.

