### PR TITLE
Default port and scope for ws and net

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function (plugs, wrap) {
       }
     },
     stringify: function (scope) {
-      if (!scope) scope = 'public'
+      if (!scope) scope = 'device'
       return plugs
         .filter(function (plug) {
           return plug.scope() === scope ||

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -19,7 +19,9 @@ module.exports = function (opts) {
     name: 'net',
     scope: function() { return opts.scope || 'public' },
     server: function (onConnection) {
-      var port = opts.port
+      // Choose a dynamic port between 49152 and 65535
+      // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
+      var port = opts.port || Math.floor(49152 + (65535 - 49152 + 1) * Math.random())
       var host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
       console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
       var server = net.createServer(opts, function (stream) {

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -13,16 +13,19 @@ function toDuplex (str) {
 }
 
 module.exports = function (opts) {
+  // Choose a dynamic port between 49152 and 65535
+  // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
+  var port = opts.port || Math.floor(49152 + (65535 - 49152 + 1) * Math.random())
+  var host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
+  var scope = opts.scope || 'device'
+
   // FIXME: does this even work anymore?
   opts.allowHalfOpen = opts.allowHalfOpen !== false
+  
   return {
     name: 'net',
-    scope: function() { return opts.scope || 'public' },
+    scope: function() { return scope},
     server: function (onConnection) {
-      // Choose a dynamic port between 49152 and 65535
-      // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
-      var port = opts.port || Math.floor(49152 + (65535 - 49152 + 1) * Math.random())
-      var host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
       console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
       var server = net.createServer(opts, function (stream) {
         var addr = stream.address()
@@ -74,8 +77,8 @@ module.exports = function (opts) {
       }
     },
     stringify: function (scope) {
-      var host = scope == 'public' && opts.external || opts.host || scope && scopes.host(scope) || 'localhost'
-      return ['net', host, opts.port].join(':')
+      var _host = scope == 'public' ? opts.external : host
+      return ['net', _host, port].join(':')
     }
   }
 }

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -10,7 +10,7 @@ module.exports = function (opts) {
   var secure = opts.server && !!opts.server.key
   return {
     name: 'ws',
-    scope: function() { return opts.scope || 'public' },
+    scope: function() { return opts.scope || 'device' },
     server: function (onConnect) {
       if(!WS.createServer) return
       // Choose a dynamic port between 49152 and 65535

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -13,6 +13,9 @@ module.exports = function (opts) {
     scope: function() { return opts.scope || 'public' },
     server: function (onConnect) {
       if(!WS.createServer) return
+      // Choose a dynamic port between 49152 and 65535
+      // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
+      opts.port = opts.port || Math.floor(49152 + (65535 - 49152 + 1) * Math.random())
       opts.host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
       var server = WS.createServer(opts, function (stream) {
         stream.address = 'ws:'+stream.remoteAddress + (stream.remotePort ? ':'+stream.remotePort : '')

--- a/test/multi.js
+++ b/test/multi.js
@@ -49,11 +49,10 @@ var close = multi.server(function (stream) {
 })
 
 var server_addr =
-'fake:peer.ignore~nul:what;'+multi.stringify()
+'fake:peer.ignore~nul:what;'+multi.stringify('public')
 //"fake" in a unkown protocol, just to make sure it gets skipped.
 
 tape('connect to either server', function (t) {
-
   multi.client(server_addr, function (err, stream) {
     if(err) throw err
     console.log(stream)


### PR DESCRIPTION
so that secret-stack does not have to care about default config values at all.

Note: this changes the default scope for net and ws servers to `device`. The reason for this is: The former default `public` now causes multiserver to look for a public ip to bind to. This is unlikely to be available though. localhost on the other hand is guaranteed to be available.

Another reason: defaults should be safe.

This also changes the default for the argument for stringify from `public` to `local`. If you want an address that is routable on the Internet, you now need to ask explicitly for `public`.

(These defaults of course can be overwritten in secure-stack and/or ssb-config)