### PR TITLE
support multiple scopes on one server

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ module.exports = function (plugs, wrap) {
       if (!scope) scope = 'public'
       return plugs
         .filter(function (plug) {
-          return plug.scope() === scope ||
-            (plug.scope() === 'public' && scope === 'private')
+          var _scope = plug.scope()
+          return Array.isArray(_scope) ? ~_scope.indexOf(scope) : _scope === scope
         })
         .map(function (plug) { return plug.stringify(scope) })
         .filter(Boolean)
@@ -63,4 +63,5 @@ module.exports = function (plugs, wrap) {
   }
   return _self
 }
+
 

--- a/multiscope.js
+++ b/multiscope.js
@@ -1,0 +1,42 @@
+
+var getHost = require('multiserver-scopes').host
+
+function isString (s) {
+  return 'string' === typeof s
+}
+
+var isArray = Array.isArray
+
+module.exports = function (port, scopes, createServer) {
+  scopes = scopes || 'public'
+  if(isString(scopes)) {
+    var server = createServer().listen(port, getHost(scopes))
+    return function (cb) {
+      server.close(function (err) {
+        cb && cb(err)
+      })
+    }
+  }
+  else if(isArray(scopes)) {
+    var servers = scopes.map(function (scope) {
+      return createServer().listen(port, getHost(scope))
+    })
+    return function (cb) {
+      var n = servers.length, err
+      servers.forEach(function (server) { 
+        server.close(function (_err) {
+          err = err || _err
+          if(--n) return
+          cb && cb(err)
+        })
+      })
+    }
+  }
+  else
+    throw new Error('missing scopes')
+}
+
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multiserver",
   "description": "write a server which works over many protocols at once, or connect to the same",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/dominictarr/multiserver",
   "repository": {
     "type": "git",

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -23,7 +23,6 @@ module.exports = function (opts) {
       var host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
       console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
       var server = net.createServer(opts, function (stream) {
-        var addr = stream.address()
         onConnection(toDuplex(stream))
       }).listen(port, host)
       return function (cb) {
@@ -77,3 +76,5 @@ module.exports = function (opts) {
     }
   }
 }
+
+

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -1,10 +1,11 @@
+var Multiscope = require('../multiscope')
+var scopes = require('multiserver-scopes')
 var net
 try {
   net = require('net')
 } catch (_) {}
 
 var toPull = require('stream-to-pull-stream')
-var scopes = require('multiserver-scopes')
 
 function toDuplex (str) {
   var stream = toPull.duplex(str)
@@ -20,8 +21,12 @@ module.exports = function (opts) {
     scope: function() { return opts.scope || 'public' },
     server: function (onConnection) {
       var port = opts.port
-      var host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
-      console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
+//      var host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
+  //    console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
+      return Multiscope(opts.port, opts.scope, function () {
+        return net.createServer(opts, function (stream) { onConnection(toDuplex(stream)) })
+      })
+      /*
       var server = net.createServer(opts, function (stream) {
         onConnection(toDuplex(stream))
       }).listen(port, host)
@@ -33,6 +38,7 @@ module.exports = function (opts) {
           if (cb) cb(err) 
         })
       }
+      */
     },
     client: function (opts, cb) {
       var addr = 'net:'+opts.host+':'+opts.port
@@ -76,5 +82,6 @@ module.exports = function (opts) {
     }
   }
 }
+
 
 

--- a/plugins/noauth.js
+++ b/plugins/noauth.js
@@ -22,3 +22,4 @@ module.exports = function (opts) {
     }
   }
 }
+

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -4,6 +4,28 @@ var pull = require('pull-stream/pull')
 var Map = require('pull-stream/throughs/map')
 var scopes = require('multiserver-scopes')
 
+function safe_origin (origin, address, port) {
+
+  //if the connection is not localhost, we shouldn't trust
+  //the origin header. So, use address instead of origin
+  //if origin not set, then it's definitely not a browser.
+  if(!(address === '::1' || address === '128.0.0.1') || origin == undefined)
+    return 'ws:' + address + (port ? ':' + port : '')
+
+  //note: origin "null" (as string) can happen a bunch of ways
+  //      it can be a html opened as a file
+  //      or certain types of CORS
+  //      https://www.w3.org/TR/cors/#resource-sharing-check-0
+  //      and webworkers if loaded from data-url?
+  if(origin === 'null')
+    return 'ws:null'
+
+  //a connection from the browser on localhost,
+  //we choose to trust this came from a browser.
+  return origin.replace(/^http/, 'ws')
+
+}
+
 module.exports = function (opts) {
   opts = opts || {}
   opts.binaryType = (opts.binaryType || 'arraybuffer')
@@ -15,7 +37,11 @@ module.exports = function (opts) {
       if(!WS.createServer) return
       opts.host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
       var server = WS.createServer(opts, function (stream) {
-        stream.address = 'ws:'+stream.remoteAddress + (stream.remotePort ? ':'+stream.remotePort : '')
+        stream.address = safe_origin(
+          stream.headers.origin,
+          stream.remoteAddress,
+          stream.remotePort
+        )
         onConnect(stream)
       })
 

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -9,7 +9,7 @@ function safe_origin (origin, address, port) {
   //if the connection is not localhost, we shouldn't trust
   //the origin header. So, use address instead of origin
   //if origin not set, then it's definitely not a browser.
-  if(!(address === '::1' || address === '128.0.0.1') || origin == undefined)
+  if(!(address === '::1' || address === '127.0.0.1') || origin == undefined)
     return 'ws:' + address + (port ? ':' + port : '')
 
   //note: origin "null" (as string) can happen a bunch of ways

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -97,8 +97,7 @@ tape('combined', function (t) {
   })
 })
 
-if (has_ipv6)
-tape('combined, ipv6', function (t) {
+if (has_ipv6)tape('combined, ipv6', function (t) {
   var combined = Compose([
     Net({
       port: 4848,
@@ -130,22 +129,20 @@ tape('net: do not listen on all addresses', function (t) {
   var combined = Compose([
     Net({
       port: 4848,
-      host: 'localhost',
+      scope: 'device',
       external: scopes.host('private') // unroutable IP, but not localhost (e.g. 192.168 ...)
     }),
     shs
   ])
   var close = combined.server(echo)
 
-  var addr = combined.stringify('public') // returns external
+  var addr = combined.stringify('local') // returns external
   console.log('addr public scope', addr)
   combined.client(addr, function (err, stream) {
     t.ok(err, 'should only listen on localhost')
     close(function() {t.end()})
   })
 })
-
-
 
 tape('ws with combined', function (t) {
   var close = combined_ws.server(function (stream) {
@@ -340,4 +337,8 @@ tape('error should have client address on it', function (t) {
     t.end()
   })
 })
+
+
+
+
 

--- a/test/scopes.js
+++ b/test/scopes.js
@@ -1,0 +1,199 @@
+var tape = require('tape')
+var pull = require('pull-stream')
+var Pushable = require('pull-pushable')
+
+var Compose = require('../compose')
+var Net = require('../plugins/net')
+var Ws = require('../plugins/ws')
+var Shs = require('../plugins/shs')
+var Onion = require('../plugins/onion')
+var MultiServer = require('../')
+
+var cl = require('chloride')
+var seed1 = cl.crypto_hash_sha256(Buffer.from('TESTSEED'))
+var seed2 = cl.crypto_hash_sha256(Buffer.from('TESTSEED'))
+var keys1 = cl.crypto_sign_seed_keypair(seed1)
+var keys2 = cl.crypto_sign_seed_keypair(seed2)
+var appKey = cl.crypto_hash_sha256(Buffer.from('TEST'))
+
+var requested, ts
+
+//this gets overwritten in the last test.
+var check = function (id, cb) {
+  cb(null, true)
+}
+
+var net_local = Net({port: 4848, scope: 'local'})
+var net_device = Net({port: 4848, scope: 'device'})
+
+function allow (id, cb) { cb(null, true) }
+var shs = Shs({keys: keys1, appKey: appKey, auth: allow})
+
+var device = Compose([net_device, shs])
+var local = Compose([net_local, shs])
+var multi = MultiServer([ device, local ])
+var local_device = Net({port: 4848, scope: ['local', 'device']})
+var multi2 = MultiServer([[local_device, shs]])
+
+tape('local and device are two addresses', function (t) {
+  t.ok(/localhost/.test(multi.stringify('device')))
+  t.ok(/192\.168\.\d+\d+/.test(multi.stringify('local')))
+  t.end()
+})
+
+var close
+
+
+function connect (multi, name) {
+  tape(name+'.server', function (t) {
+    close = multi.server(function (stream) {
+      console.log('stream', stream.address)
+      stream.source(true, function () {})
+    })
+    t.end()
+  })
+
+  tape(name+'.client - device', function (t) {
+    multi.client(multi.stringify('device'), function (err) {
+      if(err) throw err
+      t.end()
+    })
+  })
+
+  tape(name+'.client - local', function (t) {
+    multi.client(multi.stringify('local'), function (err) {
+      if(err) throw err
+      t.end()
+    })
+  })
+  tape('close', function (t) {
+    close(t.end)
+  })
+
+}
+connect(multi, 'multi')
+
+tape('double', function (t) {
+  //var net_local_device = 
+  console.log(multi2.stringify('local'))
+  t.ok(/localhost/.test(multi2.stringify('device')))
+  t.ok(/192\.168\.\d+\d+/.test(multi2.stringify('local')))
+  t.equal(multi2.stringify('local'), multi.stringify('local'))
+  t.equal(multi2.stringify('device'), multi.stringify('device'))
+  t.end()
+})
+
+connect(multi2, 'multi2')
+
+
+return
+var multi_ws = MultiServer([ combined_ws ])
+var multi_net = MultiServer([ combined ])
+
+var client_addr
+
+var close = multi.server(function (stream) {
+  console.log("onConnect", stream.address)
+  client_addr = stream.address
+  pull(stream, stream)
+})
+
+var server_addr =
+'fake:peer.ignore~nul:what;'+multi.stringify()
+//"fake" in a unkown protocol, just to make sure it gets skipped.
+
+tape('connect to either server', function (t) {
+
+  multi.client(server_addr, function (err, stream) {
+    if(err) throw err
+    console.log(stream)
+    t.ok(/^net/.test(client_addr), 'client connected via net')
+    t.ok(/^net/.test(stream.address), 'client connected via net')
+    pull(
+      pull.values([Buffer.from('Hello')]),
+      stream,
+      pull.collect(function (err,  ary) {
+        var data = Buffer.concat(ary).toString('utf8')
+        console.log("OUTPUT", data)
+//        close()
+        t.end()
+      })
+    )
+  })
+})
+
+tape('connect to either server', function (t) {
+
+  console.log(multi.stringify())
+
+  multi_ws.client(server_addr, function (err, stream) {
+    if(err) throw err
+    t.ok(/^ws/.test(client_addr), 'client connected via ws')
+    t.ok(/^ws/.test(stream.address), 'client connected via net')
+    pull(
+      pull.values([Buffer.from('Hello')]),
+      stream,
+      pull.collect(function (err,  ary) {
+        var data = Buffer.concat(ary).toString('utf8')
+        console.log("OUTPUT", data)
+        t.end()
+      })
+    )
+  })
+})
+
+tape('connect to either server', function (t) {
+
+  multi_net.client(server_addr, function (err, stream) {
+    if(err) throw err
+    t.ok(/^net/.test(client_addr), 'client connected via net')
+    t.ok(/^net/.test(stream.address), 'client connected via net')
+    pull(
+      pull.values([Buffer.from('Hello')]),
+      stream,
+      pull.collect(function (err,  ary) {
+        var data = Buffer.concat(ary).toString('utf8')
+        console.log("OUTPUT", data)
+        t.end()
+      })
+    )
+  })
+})
+
+tape('close', function (t) {
+  close()
+  t.end()
+})
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
As suggested in https://github.com/ssbc/ssb-config/issues/24#issuecomment-434251335
I implemented support for multiple scopes.

This enables you to say host a server at ["device", "local"] which will make `scuttlebot/bin.js` work unchanged, but will also allow peers on the local network to connect to the same encrypted connection.
also, without needing extensive configuration.

I think this gets us both explicit binding as you wanted @regular and also means bin works (even with old sbot or git-ssb etc).

to listen on all addresses, you also don't need loads of lines of config (which are easy to mess up)