### PR TITLE
Set immediate before connecting to server

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,15 +15,17 @@ module.exports = function (plugs, wrap) {
   var _self = {
     name: plugs.map(function (e) { return e.name }).join(';'),
     client: function (addr, cb) {
-      var _addr = split(addr).find(function (addr) {
-        //connect with the first plug that understands this string.
-        plug = plugs.find(function (plug) {
-          return plug.parse(addr) ? plug : null
+      setImmediate(function () {
+        var _addr = split(addr).find(function (addr) {
+          //connect with the first plug that understands this string.
+          plug = plugs.find(function (plug) {
+            return plug.parse(addr) ? plug : null
+          })
+          if(plug) return addr
         })
-        if(plug) return addr
+        if(plug) plug.client(_addr, cb)
+        else cb(new Error('could not connect to:'+addr+', only know:'+_self.name))
       })
-      if(plug) plug.client(_addr, cb)
-      else cb(new Error('could not connect to:'+addr+', only know:'+_self.name))
     },
     server: function (onConnect, onError) {
       //start all servers
@@ -63,4 +65,8 @@ module.exports = function (plugs, wrap) {
   }
   return _self
 }
+
+
+
+
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multiserver",
   "description": "write a server which works over many protocols at once, or connect to the same",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/dominictarr/multiserver",
   "repository": {
     "type": "git",

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -23,7 +23,6 @@ module.exports = function (opts) {
       var host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
       console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
       var server = net.createServer(opts, function (stream) {
-        var addr = stream.address()
         onConnection(toDuplex(stream))
       }).listen(port, host)
       return function (cb) {
@@ -77,3 +76,5 @@ module.exports = function (opts) {
     }
   }
 }
+
+

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -4,6 +4,28 @@ var pull = require('pull-stream/pull')
 var Map = require('pull-stream/throughs/map')
 var scopes = require('multiserver-scopes')
 
+function safe_origin (origin, address, port) {
+
+  //if the connection is not localhost, we shouldn't trust
+  //the origin header. So, use address instead of origin
+  //if origin not set, then it's definitely not a browser.
+  if(!(address === '::1' || address === '128.0.0.1') || origin == undefined)
+    return 'ws:' + address + (port ? ':' + port : '')
+
+  //note: origin "null" (as string) can happen a bunch of ways
+  //      it can be a html opened as a file
+  //      or certain types of CORS
+  //      https://www.w3.org/TR/cors/#resource-sharing-check-0
+  //      and webworkers if loaded from data-url?
+  if(origin === 'null')
+    return 'ws:null'
+
+  //a connection from the browser on localhost,
+  //we choose to trust this came from a browser.
+  return origin.replace(/^http/, 'ws')
+
+}
+
 module.exports = function (opts) {
   opts = opts || {}
   opts.binaryType = (opts.binaryType || 'arraybuffer')
@@ -15,7 +37,11 @@ module.exports = function (opts) {
       if(!WS.createServer) return
       opts.host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
       var server = WS.createServer(opts, function (stream) {
-        stream.address = 'ws:'+stream.remoteAddress + (stream.remotePort ? ':'+stream.remotePort : '')
+        stream.address = safe_origin(
+          stream.headers.origin,
+          stream.remoteAddress,
+          stream.remotePort
+        )
         onConnect(stream)
       })
 


### PR DESCRIPTION
I think this will fix the problem in described in `%lPTvlvFSyZnTUbQk+rEjis0L6cuf87hAOFXTWGpT8GQ=.sha256` brought back to my attention via https://github.com/ssbc/ssb-config/pull/23#issuecomment-434704957

> The difference is in whether you give the client an external IP (from getAddress()) as the remote, or leave that empty and leave it to the client to assemble the address with localhost) I've looked at the scuttlebot tests and they all use getAddress for the remote. 

so I think if we put a setImmediate inside multiserver.client we have the same effect as a setImmediate around everything, without having to change the api at all.