### PR TITLE
support multiple scopes, take 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,7 @@ module.exports = function (plugs, wrap) {
       if (!scope) scope = 'device'
       return plugs
         .filter(function (plug) {
-          return plug.scope() === scope ||
-            (plug.scope() === 'public' && scope === 'private')
+          return plug.scope() === scope
         })
         .map(function (plug) { return plug.stringify(scope) })
         .filter(Boolean)
@@ -63,4 +62,5 @@ module.exports = function (plugs, wrap) {
   }
   return _self
 }
+
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,8 @@ module.exports = function (plugs, wrap) {
       if (!scope) scope = 'device'
       return plugs
         .filter(function (plug) {
-          return plug.scope() === scope
+          var _scope = plug.scope()
+          return Array.isArray(_scope) ? ~_scope.indexOf(scope) : _scope === scope
         })
         .map(function (plug) { return plug.stringify(scope) })
         .filter(Boolean)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multiserver",
   "description": "write a server which works over many protocols at once, or connect to the same",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/dominictarr/multiserver",
   "repository": {
     "type": "git",

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -18,7 +18,6 @@ module.exports = function (opts) {
   var port = opts.port || Math.floor(49152 + (65535 - 49152 + 1) * Math.random())
   var host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
   var scope = opts.scope || 'device'
-
   // FIXME: does this even work anymore?
   opts.allowHalfOpen = opts.allowHalfOpen !== false
 
@@ -28,7 +27,9 @@ module.exports = function (opts) {
   
   return {
     name: 'net',
-    scope: function() { return scope },
+    scope: function() {
+      return scope
+    },
     server: function (onConnection) {
       console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
       var server = net.createServer(opts, function (stream) {
@@ -83,9 +84,9 @@ module.exports = function (opts) {
       scope = scope || 'device'
       if(!isScoped(scope)) return
       var _host = (scope == 'public' && opts.external) || scopes.host(scope)
+      if(!_host) return null
       return ['net', _host, port].join(':')
     }
   }
 }
-
 

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -21,10 +21,14 @@ module.exports = function (opts) {
 
   // FIXME: does this even work anymore?
   opts.allowHalfOpen = opts.allowHalfOpen !== false
+
+  function isScoped (s) {
+    return s === scope || Array.isArray(scope) && ~scope.indexOf(s)
+  }
   
   return {
     name: 'net',
-    scope: function() { return scope},
+    scope: function() { return scope },
     server: function (onConnection) {
       console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
       var server = net.createServer(opts, function (stream) {
@@ -76,7 +80,9 @@ module.exports = function (opts) {
       }
     },
     stringify: function (scope) {
-      var _host = scope == 'public' ? opts.external : host
+      scope = scope || 'device'
+      if(!isScoped(scope)) return
+      var _host = (scope == 'public' && opts.external) || scopes.host(scope)
       return ['net', _host, port].join(':')
     }
   }

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -36,7 +36,7 @@ module.exports = function (opts) {
       socks.createConnection(serverOpts, function (err, socket) {
         if(err) {
           console.error('unable to find local tor server.')
-	  console.error('will be able receive tor connections') // << ???
+          console.error('will be able receive tor connections') // << ???
           return
         }
         controlSocket = socket
@@ -101,8 +101,9 @@ module.exports = function (opts) {
         port: port
       }
     },
-    stringify: function () {
-      if(opts && !opts.server) return
+    stringify: function (scope) {
+      if(scope !== opts.scope) return null
+      if(opts && !opts.server) return null
       return ['onion', opts.host, opts.port].join(':')
     }
   }

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -9,11 +9,11 @@ var started = false
 module.exports = function (opts) {
   const socket = path.join(opts.path || '', 'socket')
   const addr = 'unix:' + socket
-
+  const scope = opts.scope || 'device'
   opts = opts || {}
   return {
     name: 'unix',
-    scope: function() { return opts.scope || 'public' },
+    scope: function() { return scope },
     server: !opts.server ? null : function (onConnection) {
       if(started) return
       console.log("listening on socket", addr)
@@ -83,8 +83,9 @@ module.exports = function (opts) {
         path: ary.shift()
       }
     },
-    stringify: function () {
-      if(opts && !opts.server) return
+    stringify: function (_scope) {
+      if(scope !== _scope) return null
+      if(opts && !opts.server) return null
       return ['unix', socket].join(':')
     }
   }

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -43,7 +43,6 @@ module.exports = function (opts) {
       // Choose a dynamic port between 49152 and 65535
       // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
       opts.port = opts.port || Math.floor(49152 + (65535 - 49152 + 1) * Math.random())
-      opts.host = opts.host || opts.scope && scopes.host(opts.scope) || 'localhost'
       var server = WS.createServer(opts, function (stream) {
         stream.address = safe_origin(
           stream.headers.origin,

--- a/test/multi.js
+++ b/test/multi.js
@@ -21,8 +21,8 @@ var check = function (id, cb) {
   cb(null, true)
 }
 
-var net = Net({port: 4848, scope: 'public'})
-var ws = Ws({port: 4849, scope: 'public'})
+var net = Net({port: 4848, scope: 'device'})
+var ws = Ws({port: 4849, scope: 'device'})
 var shs = Shs({keys: keys, appKey: appKey, auth: function (id, cb) {
   requested = id
   ts = Date.now()
@@ -48,11 +48,13 @@ var close = multi.server(function (stream) {
   pull(stream, stream)
 })
 
+
 var server_addr =
-'fake:peer.ignore~nul:what;'+multi.stringify('public')
+'fake:peer.ignore~nul:what;'+multi.stringify('device')
 //"fake" in a unkown protocol, just to make sure it gets skipped.
 
 tape('connect to either server', function (t) {
+  t.ok(multi.stringify('device'))
   multi.client(server_addr, function (err, stream) {
     if(err) throw err
     console.log(stream)
@@ -64,7 +66,6 @@ tape('connect to either server', function (t) {
       pull.collect(function (err,  ary) {
         var data = Buffer.concat(ary).toString('utf8')
         console.log("OUTPUT", data)
-//        close()
         t.end()
       })
     )
@@ -72,8 +73,6 @@ tape('connect to either server', function (t) {
 })
 
 tape('connect to either server', function (t) {
-
-  console.log(multi.stringify())
 
   multi_ws.client(server_addr, function (err, stream) {
     if(err) throw err


### PR DESCRIPTION
this supercedes: https://github.com/ssbc/multiserver/pull/29

instead of creating several servers binding to particular addresses, one for each scope, the scope is only considered a label. The server is bound to what ever host you give - so if you wish to use multiple scopes, I recommend '::' as the host. but then, when an address is requested, if it is within scope, then it uses the scope to pick an ip address (and public scope uses `external`)

This is simpler than the previous one, and still meets the main uses cases
* server without encryption strictly on localhost.
* server with encryption on localhost and local network. (this would actually open to a public address too, if you happened to have one)

If there _isn't_ a suitable address available, this will act like it's out of scope, and _not_ return an address.

I think this addresses everyone's use cases? @regular @arj03 ?