### PR TITLE
add test for unix-socket plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+os:
+  - linux
+  - osx
+
 language: node_js
 sudo: false
 node_js:
   - 8
-  - 6
   - 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,8 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm test
+  - node test/async-server-close.js
+  - node test/multi.js
+  - node test/plugs.js
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+# https://www.appveyor.com/docs/lang/nodejs-iojs/
+
+cache:
+  - node_modules
+
+init:
+  - git config --global core.autocrlf input
+
+environment:
+  matrix:
+    - nodejs_version: "8"
+    - nodejs_version: "10"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+build: off

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -40,7 +40,7 @@ module.exports = function (opts) {
         }
       })
 
-      if (os.platform() !== 'windows') {
+      if (process.platform !== 'windows') {
         fs.chmodSync(socket, 0600)
       }
 

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -40,7 +40,9 @@ module.exports = function (opts) {
         }
       })
 
-      fs.chmodSync(socket, 0600)
+      if (os.platform() !== 'windows') {
+        fs.chmodSync(socket, 0600)
+      }
 
       started = true
 

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -40,7 +40,7 @@ module.exports = function (opts) {
         }
       })
 
-      if (process.platform !== 'windows') {
+      if (process.platform !== 'win32') {
         fs.chmodSync(socket, 0600)
       }
 

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -160,7 +160,7 @@ tape('net: do not listen on all addresses', function (t) {
 })
 
 tape('combined, unix', function (t) {
-  var p = '/tmp/multitest'+(new Date()).getTime()
+  var p = 'multiunixtest'+(new Date()).getTime()
   fs.mkdirSync(p)
   var combined = Compose([
     Unix({


### PR DESCRIPTION
I noticed there were no tests for this plugin so I added at least this one. also verifies @arj03 comment on the linked issue, that the `server:true` option is needed.

(updates ssbc/scuttlebot#577)