### PR TITLE
Introduce callback parameter for when a multiserver server has finished initialising

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -102,7 +102,7 @@ module.exports = function (ary, wrap) {
             else onConnection(stream)
           }
         )
-      }))
+      }, onStart))
     },
     parse: parse,
     stringify: function (scope) {

--- a/compose.js
+++ b/compose.js
@@ -88,7 +88,7 @@ module.exports = function (ary, wrap) {
     // There should be a callback , called with
     // null when the server started to listen.
     // (net.server.listen is async for example)
-    server: function (onConnection, onError) {
+    server: function (onConnection, onError, onStart) {
       onError = onError || function (err) {
         console.error('server error, from', err.address)
         console.error(err.stack)

--- a/index.js
+++ b/index.js
@@ -25,11 +25,21 @@ module.exports = function (plugs, wrap) {
       if(plug) plug.client(_addr, cb)
       else cb(new Error('could not connect to:'+addr+', only know:'+_self.name))
     },
-    server: function (onConnect, onError) {
+    server: function (onConnect, onError, startedCb) {
       //start all servers
+
+      if (!startedCb)
+        startedCb = (err, res) => {}
+
+      var started = multicb()
+
       var closes = plugs.map(function (plug) {
-        return plug.server(onConnect, onError)
+        var hm = started()
+
+        return plug.server(onConnect, onError, hm)
       }).filter(Boolean)
+
+      started(startedCb);
 
       return function (cb) {
         var done

--- a/index.js
+++ b/index.js
@@ -29,7 +29,14 @@ module.exports = function (plugs, wrap) {
       //start all servers
 
       if (!startedCb) {
-        startedCb = () => {}
+        // If a callback is not registered to be called back when the servers are
+        // fully started, our default behaviour is just to print any errors starting
+        // the servers to the log
+        startedCb = (err, result) => {
+          if (err) {
+            console.error("Error starting multiserver server: " + err)
+          }
+        }
       }
 
       var started = multicb()

--- a/index.js
+++ b/index.js
@@ -28,15 +28,14 @@ module.exports = function (plugs, wrap) {
     server: function (onConnect, onError, startedCb) {
       //start all servers
 
-      if (!startedCb)
-        startedCb = (err, res) => {}
+      if (!startedCb) {
+        startedCb = () => {}
+      }
 
       var started = multicb()
 
       var closes = plugs.map(function (plug) {
-        var hm = started()
-
-        return plug.server(onConnect, onError, hm)
+        return plug.server(onConnect, onError, started())
       }).filter(Boolean)
 
       started(startedCb);

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -39,12 +39,7 @@ module.exports = function (opts) {
       console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
       var server = net.createServer(opts, function (stream) {
         onConnection(toDuplex(stream))
-      }).listen(port, host, (a, b) => {
-        console.log(a);
-        console.log(b);
-
-        startedCb(a,b)
-      })
+      }).listen(port, host, startedCb)
       return function (cb) {
         console.log('Closing server on ' + host + ':' + port + ' (multiserver net plugin)')
         server.close(function(err) {

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -39,7 +39,12 @@ module.exports = function (opts) {
       console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
       var server = net.createServer(opts, function (stream) {
         onConnection(toDuplex(stream))
-      }).listen(port, host, 511, startedCb)
+      }).listen(port, host, (a, b) => {
+        console.log(a);
+        console.log(b);
+
+        startedCb(a,b)
+      })
       return function (cb) {
         console.log('Closing server on ' + host + ':' + port + ' (multiserver net plugin)')
         server.close(function(err) {

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -35,11 +35,11 @@ module.exports = function (opts) {
     scope: function() {
       return scope
     },
-    server: function (onConnection) {
+    server: function (onConnection, startedCb) {
       console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
       var server = net.createServer(opts, function (stream) {
         onConnection(toDuplex(stream))
-      }).listen(port, host)
+      }).listen(port, host, 511, startedCb)
       return function (cb) {
         console.log('Closing server on ' + host + ':' + port + ' (multiserver net plugin)')
         server.close(function(err) {

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -21,7 +21,7 @@ module.exports = function (opts) {
   return {
     name: 'onion',
     scope: function() { return opts.scope || 'public' },
-    server: function (onConnection) {
+    server: function (onConnection, cb) {
       if(!opts.server) return
 
       var serverOpts = {
@@ -45,11 +45,14 @@ module.exports = function (opts) {
           stream = toPull.duplex(stream)
           stream.address = 'onion:'
           onConnection(stream)
+          
+          cb(null, true);
         })
 
         // Remember to resume the socket stream.
         socket.resume()
       })
+
       return function () {
         if (controlSocket != null)
           controlSocket.end()

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -46,8 +46,9 @@ module.exports = function (opts) {
           stream.address = 'onion:'
           onConnection(stream)
           
-          cb(null, true);
         })
+
+        cb(null, true);
 
         // Remember to resume the socket stream.
         socket.resume()

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -14,7 +14,7 @@ module.exports = function (opts) {
   return {
     name: 'unix',
     scope: function() { return scope },
-    server: !opts.server ? null : function (onConnection) {
+    server: !opts.server ? null : function (onConnection, cb) {
       if(started) return
       console.log("listening on socket", addr)
 
@@ -22,7 +22,7 @@ module.exports = function (opts) {
         stream = toDuplex(stream)
         stream.address = addr
         onConnection(stream)
-      }).listen(socket)
+      }).listen(socket, 511, cb)
 
       server.on('error', function (e) {
         if (e.code == 'EADDRINUSE') {

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -22,7 +22,7 @@ module.exports = function (opts) {
         stream = toDuplex(stream)
         stream.address = addr
         onConnection(stream)
-      }).listen(socket, 511, cb)
+      }).listen(socket, cb)
 
       server.on('error', function (e) {
         if (e.code == 'EADDRINUSE') {

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -39,7 +39,12 @@ module.exports = function (opts) {
   return {
     name: 'ws',
     scope: function() { return opts.scope || 'device' },
-    server: function (onConnect) {
+    server: function (onConnect, onError, startedCb) {
+      console.log("eh?")
+      console.log(onConnect)
+      console.log(onError)
+      console.log(startedCb)
+
       if(!WS.createServer) return
       // Choose a dynamic port between 49152 and 65535
       // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
@@ -55,6 +60,8 @@ module.exports = function (opts) {
         )
         onConnect(stream)
       })
+
+      startedCb(null, true)
 
       if(!opts.server) {
         console.log('Listening on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -39,11 +39,7 @@ module.exports = function (opts) {
   return {
     name: 'ws',
     scope: function() { return opts.scope || 'device' },
-    server: function (onConnect, onError, startedCb) {
-      console.log("eh?")
-      console.log(onConnect)
-      console.log(onError)
-      console.log(startedCb)
+    server: function (onConnect, startedCb) {
 
       if(!WS.createServer) return
       // Choose a dynamic port between 49152 and 65535


### PR DESCRIPTION
# Motivation

Some multiserver servers need to do some asynchronous actions before they have reached a state that they are ready to use.

For example, (ssb-bluetooth-mobile-manager)[https://github.com/Happy0/ssb-mobile-bluetooth-manager/] is implemented in such a way that it cannot know the device's mac address until it has performed some asynchronous IO. This means it cannot return an accurate result for the multiserver `.stringify()` function.

This change introduces a call back parameter that is called when all the multiserver servers have successfully started.

# API Changes

* The `server` function in `index.js` now takes an additional parameter (`startedCb`). 

* Each multiserver plugin will be expected handle a new `startedCb` parameter in their `server` function signature, that they will call back when they are finished intialising the server.

* If the `startedCb` parameter is omitted when calling `multiserver.server` then a default one that does nothing will be called back.


