### PR TITLE
include and use new dependency: debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/dominictarr/multiserver.git"
   },
   "dependencies": {
+    "debug": "^4.1.1",
     "multicb": "^1.2.2",
     "multiserver-scopes": "^1.0.0",
     "pull-cat": "~1.1.5",

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -9,6 +9,7 @@ function isString(s) {
 
 var toPull = require('stream-to-pull-stream')
 var scopes = require('multiserver-scopes')
+var debug = require('debug')('multiserver:net')
 
 function toDuplex (str) {
   var stream = toPull.duplex(str)
@@ -29,23 +30,23 @@ module.exports = function (opts) {
   function isScoped (s) {
     return s === scope || Array.isArray(scope) && ~scope.indexOf(s)
   }
-  
+
   return {
     name: 'net',
     scope: function() {
       return scope
     },
     server: function (onConnection, startedCb) {
-      console.log('Listening on ' + host + ':' + port + ' (multiserver net plugin)')
+      debug('Listening on %s:%d', host, port)
       var server = net.createServer(opts, function (stream) {
         onConnection(toDuplex(stream))
       }).listen(port, host, startedCb)
       return function (cb) {
-        console.log('Closing server on ' + host + ':' + port + ' (multiserver net plugin)')
+        debug('Closing server on %s:%d', host, port)
         server.close(function(err) {
           if (err) console.error(err)
-          else console.log('No longer listening on ' + host + ':' + port + ' (multiserver net plugin)')
-          if (cb) cb(err) 
+          else debug('No longer listening on %s:%d', host, port)
+          if (cb) cb(err)
         })
       }
     },

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -1,9 +1,10 @@
 var socks = require('socks').SocksClient;
 var toPull = require('stream-to-pull-stream')
+var debug = require('debug')('multiserver:onion')
 
 module.exports = function (opts) {
   if(!socks) { //we are in browser
-    console.warn('onion dialing through socks proxy not supported in browser setting')
+    debug('onion dialing through socks proxy not supported in browser setting')
     return {
       name: 'onion',
       scope: function() { return 'public' },
@@ -45,7 +46,6 @@ module.exports = function (opts) {
           stream = toPull.duplex(stream)
           stream.address = 'onion:'
           onConnection(stream)
-          
         })
 
         cb(null, true);

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -2,6 +2,7 @@ var toDuplex = require('stream-to-pull-stream').duplex
 var net = require('net')
 var fs = require('fs')
 var path = require('path')
+var debug = require('debug')('multiserver:unix')
 
 // hax on double transform
 var started = false
@@ -16,7 +17,7 @@ module.exports = function (opts) {
     scope: function() { return scope },
     server: !opts.server ? null : function (onConnection, cb) {
       if(started) return
-      console.log("listening on socket", addr)
+      debug('listening on socket %s', addr)
 
       var server = net.createServer(opts, function (stream) {
         stream = toDuplex(stream)
@@ -35,7 +36,7 @@ module.exports = function (opts) {
           })
 
           clientSocket.connect({ path: socket }, function() {
-            console.log("someone else is listening on socket!")
+            debug('someone else is listening on socket!')
           })
         }
       })
@@ -49,7 +50,7 @@ module.exports = function (opts) {
       }
     },
     client: function (opts, cb) {
-      console.log("unix socket client")
+      debug('unix socket client')
       var started = false
       var stream = net.connect(opts.path)
         .on('connect', function () {
@@ -61,7 +62,7 @@ module.exports = function (opts) {
           cb(null, _stream)
         })
         .on('error', function (err) {
-          console.log("err?", err)
+          debug('err? %o', err)
           if(started) return
           started = true
           cb(err)

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -4,6 +4,7 @@ var pull = require('pull-stream/pull')
 var Map = require('pull-stream/throughs/map')
 var scopes = require('multiserver-scopes')
 var http = require('http')
+var debug = require('debug')('multiserver:ws')
 
 function safe_origin (origin, address, port) {
 
@@ -58,7 +59,7 @@ module.exports = function (opts) {
       })
 
       if(!opts.server) {
-        console.log('Listening on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')
+        debug('Listening on %s:%d', opts.host, opts.port)
         server.listen(opts.port, function () {
           startedCb && startedCb(null, true)
         })
@@ -67,11 +68,11 @@ module.exports = function (opts) {
         startedCb && startedCb(null, true)
 
       return function (cb) {
-        console.log('Closing server on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')
+        debug('Closing server on %s:%d', opts.host, opts.port)
         server.close(function(err) {
           if (err) console.error(err)
-          else console.log('No longer listening on ' + opts.host +':' + opts.port + ' (multiserver ws plugin)')
-          if (cb) cb(err) 
+          else debug('No longer listening on %s:%d', opts.host, opts.port)
+          if (cb) cb(err)
         })
       }
     },


### PR DESCRIPTION
In `secret-stack` we're using `debug` for logging, while multiserver is using console.log trashing stdout. This is a simple PR to replace console.log with debug.