### PR TITLE
Use socks type 4, as that works with new socks auth in tor 0.3.5.7 by default

### DIFF
--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -16,7 +16,7 @@ module.exports = function (opts) {
     ipaddress: "127.0.0.1",
     //TODO: tor port should be configurable.
     port: 9050, // default tor port
-    type: 5
+    type: 4
   }
   return {
     name: 'onion',


### PR DESCRIPTION
Latest version of tor doesn't work out of the box anymore. This minor patch fixes it without any config changes to tor. 

I have creating an issue upstream, but would rather have this small fix in so that other people don't run into the same problem.

The relevant parts of man tor that describes the change:

```
PreferSOCKSNoAuth
               Ordinarily, when an application offers both "username/password authentication" and "no authentication" to Tor via SOCKS5, Tor selects username/password authentication so that
               IsolateSOCKSAuth can work. This can confuse some applications, if they offer a username/password combination then get confused when asked for one. You can disable this behavior, so that Tor
               will select "No authentication" when IsolateSOCKSAuth is disabled, or when this option is set.
```

and

```
IsolateSOCKSAuth
               Don't share circuits with streams for which different SOCKS authentication was provided. (For HTTPTunnelPort connections, this option looks at the Proxy-Authorization and
               X-Tor-Stream-Isolation headers. On by default; you can disable it with NoIsolateSOCKSAuth.)
```