### PR TITLE
Remove onion server code, don't require server in socket

### DIFF
--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -23,41 +23,7 @@ module.exports = function (opts) {
     name: 'onion',
     scope: function() { return opts.scope || 'public' },
     server: function (onConnection, cb) {
-      if(!opts.server) return
-
-      var serverOpts = {
-        proxy: proxyOpts,
-        command: "bind",
-        destination: {
-          host: opts.host,
-          port: opts.port
-        }
-      }
-      var controlSocket = null
-      socks.createConnection(serverOpts, function (err, socket) {
-        if(err) {
-          console.error('unable to find local tor server.')
-          console.error('will be able receive tor connections') // << ???
-          return
-        }
-        controlSocket = socket
-
-        socket.on('data', function(stream) {
-          stream = toPull.duplex(stream)
-          stream.address = 'onion:'
-          onConnection(stream)
-        })
-
-        cb(null, true);
-
-        // Remember to resume the socket stream.
-        socket.resume()
-      })
-
-      return function () {
-        if (controlSocket != null)
-          controlSocket.end()
-      }
+      cb(new Error("Use net plugin for onion server instead"))
     },
     client: function (opts, cb) {
       var started = false, _socket, destroy
@@ -106,10 +72,7 @@ module.exports = function (opts) {
       }
     },
     stringify: function (scope) {
-      if(scope !== opts.scope) return null
-      if(opts && !opts.server) return null
-      return ['onion', opts.host, opts.port].join(':')
+      return null
     }
   }
 }
-

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -10,7 +10,7 @@ var started = false
 module.exports = function (opts) {
   const socket = path.join(opts.path || '', 'socket')
   const addr = 'unix:' + socket
-  const scope = opts.scope || 'device'
+  let scope = opts.scope || 'device'
   opts = opts || {}
   return {
     name: 'unix',
@@ -18,9 +18,9 @@ module.exports = function (opts) {
     server: function (onConnection, cb) {
       if (started) return
 
-      if (opts.scope !== "device" && !opts.server) {
-        debug('Insecure scope for unix socket! If you really want this, you need to provide pass a \'server: true\' option')
-        return
+      if (scope !== "device") {
+        debug('Insecure scope for unix socket! Reverting to device scope')
+        scope = 'device'
       }
 
       debug('listening on socket %s', addr)

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -18,6 +18,11 @@ module.exports = function (opts) {
     server: function (onConnection, cb) {
       if (started) return
 
+      if (opts.scope !== "device" && !opts.server) {
+        debug('Insecure scope for unix socket! If you really want this, you need to provide pass a \'server: true\' option')
+        return
+      }
+
       debug('listening on socket %s', addr)
 
       var server = net.createServer(opts, function (stream) {

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -15,8 +15,9 @@ module.exports = function (opts) {
   return {
     name: 'unix',
     scope: function() { return scope },
-    server: !opts.server ? null : function (onConnection, cb) {
-      if(started) return
+    server: function (onConnection, cb) {
+      if (started) return
+
       debug('listening on socket %s', addr)
 
       var server = net.createServer(opts, function (stream) {
@@ -86,9 +87,7 @@ module.exports = function (opts) {
     },
     stringify: function (_scope) {
       if(scope !== _scope) return null
-      if(opts && !opts.server) return null
       return ['unix', socket].join(':')
     }
   }
 }
-

--- a/test/multi.js
+++ b/test/multi.js
@@ -52,10 +52,7 @@ tape('listen', function (t) {
     client_addr = stream.address
     pull(stream, stream)
   }, null, t.end)
-
 })
-
-
 
 var server_addr =
 'fake:peer.ignore~nul:what;'+multi.stringify('device')

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -254,14 +254,15 @@ tape('wss default port', function (t) {
 })
 
 
-var onion = Onion({server:false, scope: 'public'})
+var onion = Onion({scope: 'public'})
 
-tape('onion plug, server false', function (t) {
+tape('onion plug', function (t) {
 
-  t.notOk(onion.stringify('public'))
-
+  // onion has no server
+  t.equal(onion.stringify('public'), null)
   t.equal(onion.stringify('device'), null)
   t.equal(onion.stringify('local'), null)
+
   t.deepEqual(
     onion.parse('onion:3234j5sv346bpih2.onion:2349'),
     {
@@ -273,11 +274,10 @@ tape('onion plug, server false', function (t) {
 
   var oshs = Compose([onion, shs])
 
-  //should not return an address, since onion is server: false
+  //should not return an address
   t.notOk(oshs.stringify())
 
   t.end()
-
 })
 
 tape('id of stream from server', function (t) {


### PR DESCRIPTION
This is me trying to solve #33. The PR does 2 things: 
 - First: remove onion server stuff. This was never used, I always used net, so no point in keeping that code around. 
 - Secondly this removes the server: true requirement for unix socket. I remember @dominictarr talked about safe defaults, can't remember the original thread, but the outcome of that is this: https://github.com/ssbc/multiserver/pull/27. It appears that the server: true requirement was added to unix, but the footgun was not. Given that unix socket is not enabled by default I don't think it should be a problem, as people adding it probably will copy/paste an example from ssb-config. Thinking while writing this, maybe the option should only be required if the scope is different from device. Fixed in second commit. 

Related issues: 
 - https://github.com/ssbc/ssb-server/issues/577
 - https://github.com/ssbc/ssb-config/issues/36
