### PR TITLE
Enable `opts.ipv6Only` by default

### DIFF
--- a/plugins/net.js
+++ b/plugins/net.js
@@ -27,6 +27,9 @@ module.exports = function (opts) {
   // FIXME: does this even work anymore?
   opts.allowHalfOpen = opts.allowHalfOpen !== false
 
+  // ensure that `::` doesn't also bind to `0.0.0.0`
+  opts.ipv6Only = opts.ipv6Only || true
+
   function isScoped (s) {
     return s === scope || Array.isArray(scope) && ~scope.indexOf(s)
   }

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -30,7 +30,9 @@ function safe_origin (origin, address, port) {
 
 module.exports = function (opts) {
   opts = opts || {}
-  opts.binaryType = (opts.binaryType || 'arraybuffer')
+  opts.binaryType = opts.binaryType || 'arraybuffer'
+  opts.ipv6Only = opts.ipv6Only || true
+
   var scope = opts.scope || 'device'
   function isScoped (s) {
     return s === scope || Array.isArray(scope) && ~scope.indexOf(s)


### PR DESCRIPTION
This ensures that when the host is `::` that we don't also bind on
`0.0.0.0` because we're only broadcasting the IPv6 interface when we
announce our multiserver addresses over UDP.