### PR TITLE
Ensure that we respect `opts.host` for the ws plugin

### DIFF
--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -60,7 +60,7 @@ module.exports = function (opts) {
 
       if(!opts.server) {
         debug('Listening on %s:%d', opts.host, opts.port)
-        server.listen(opts.port, function () {
+        server.listen(opts.port, opts.host, function () {
           startedCb && startedCb(null, true)
         })
       }


### PR DESCRIPTION
Resolves #43 

Quick-merging as it's tiny and trivial.