### PR TITLE
Fix `stringify()` in net and host to respect host

### DIFF
--- a/plugins/net.js
+++ b/plugins/net.js
@@ -89,7 +89,7 @@ module.exports = function (opts) {
     stringify: function (scope) {
       scope = scope || 'device'
       if(!isScoped(scope)) return
-      var _host = (scope == 'public' && opts.external) || scopes.host(scope)
+      var _host = opts.host || (scope == 'public' && opts.external) || scopes.host(scope)
       if(!_host) return null
       return ['net', _host, port].join(':')
     }

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -105,12 +105,10 @@ module.exports = ({ scope = 'device', host, port, external, allowHalfOpen, pause
       // We want to avoid using `host` if the target scope is public and some
       // external host (like example.com) is defined.
       const externalHost = targetScope === 'public' && external
-      const resultHost = externalHost || host
+      const resultHost = externalHost || host || scopes.host(targetScope)
 
       if (resultHost == null) {
-        // This should only happen if `host == null && publicHost == null`,
-        // which may not even be possible (?). This may be a candidate for
-        // removal in the future.
+        // The device has no network interface for a given `targetScope`.
         return null
       }
 

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -28,28 +28,41 @@ function safe_origin (origin, address, port) {
 
 }
 
-module.exports = function (opts) {
-  opts = opts || {}
-  opts.binaryType = (opts.binaryType || 'arraybuffer')
-  var scope = opts.scope || 'device'
-  function isScoped (s) {
+// Choose a dynamic port between 49152 and 65535
+// https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
+const getRandomPort = () =>
+  Math.floor(49152 + (65535 - 49152 + 1) * Math.random())
+
+module.exports = function (opts = {}) {
+  // This takes options for `WebSocket.Server()`:
+  // https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback
+
+  opts.binaryType = opts.binaryType || 'arraybuffer'
+  const scope = opts.scope || 'device'
+
+  function isAllowedScope (s) {
     return s === scope || Array.isArray(scope) && ~scope.indexOf(s)
   }
 
   var secure = opts.server && !!opts.server.key
   return {
     name: 'ws',
-    scope: function() { return opts.scope || 'device' },
+    scope: () => scope,
     server: function (onConnect, startedCb) {
+      if (WS.createServer == null) { 
+        return null
+      }
 
-      if(!WS.createServer) return
-      // Choose a dynamic port between 49152 and 65535
-      // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic,_private_or_ephemeral_ports
-      opts.port = opts.port || Math.floor(49152 + (65535 - 49152 + 1) * Math.random())
+      // Maybe weird: this sets a random port each time that `server()` is run
+      // whereas the net plugin sets the port when the outer function is run.
+      //
+      // This server has a random port generated at runtime rather than when
+      // the interface is instantiated. Is that the way it should work?
+      opts.port = opts.port || getRandomPort()
 
       var server = opts.server || http.createServer(opts.handler)
 
-      var ws_server = WS.createServer(Object.assign({}, opts, {server: server}), function (stream) {
+      WS.createServer(Object.assign({}, opts, {server: server}), function (stream) {
         stream.address = safe_origin(
           stream.headers.origin,
           stream.remoteAddress,
@@ -99,24 +112,27 @@ module.exports = function (opts) {
         stream.close(cb)
       }
     },
-    stringify: function (scope) {
-      scope = scope || 'device'
-      if(!isScoped(scope)) return null
-      if(!WS.createServer) return null
-      var port
-      if(opts.server)
-        port = opts.server.address().port
-      else
-        port = opts.port
+    stringify: function (targetScope = 'device') {
+      if (WS.createServer == null) {
+        return null
+      }
+      if (isAllowedScope(targetScope) === false) {
+        return null
+      }
 
-      var host = opts.host || (scope == 'public' && opts.external) || scopes.host(scope)
-      //if a public scope was requested, but a public ip is not available, return
-      if(!host) return null
+      const port = opts.server ? opts.server.address().port : opts.port
+      const externalHost = targetScope === 'public' && opts.external
+      const resultHost = externalHost || opts.host || scopes.host(targetScope)
+
+      if (resultHost == null) {
+        // The device has no network interface for a given `targetScope`.
+        return null
+      }
 
       return URL.format({
         protocol: secure ? 'wss' : 'ws',
         slashes: true,
-        hostname: host,
+        hostname: resultHost,
         port: (secure ? port == 443 : port == 80) ? undefined : port
       })
     },

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -109,7 +109,7 @@ module.exports = function (opts) {
       else
         port = opts.port
 
-      var host = (scope == 'public' && opts.external) || scopes.host(scope)
+      var host = opts.host || (scope == 'public' && opts.external) || scopes.host(scope)
       //if a public scope was requested, but a public ip is not available, return
       if(!host) return null
 

--- a/test/multi.js
+++ b/test/multi.js
@@ -78,7 +78,6 @@ tape('connect to either server', function (t) {
 })
 
 tape('connect to either server', function (t) {
-
   multi_ws.client(server_addr, function (err, stream) {
     if(err) throw err
     t.ok(/^ws/.test(client_addr), 'client connected via ws')
@@ -96,7 +95,6 @@ tape('connect to either server', function (t) {
 })
 
 tape('connect to either server', function (t) {
-
   multi_net.client(server_addr, function (err, stream) {
     if(err) throw err
     t.ok(/^net/.test(client_addr), 'client connected via net')

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -397,3 +397,32 @@ tape('error should have client address on it', function (t) {
   })
 })
 
+tape('multiple public different hosts', function(t) {
+  var net1 = Net({ host: '127.0.0.1', port: 4848, scope: 'public'})
+  var net2 = Net({ host: '::1', port: 4847, scope: 'public'})
+
+  var combined1 = Compose([net1, shs])
+  var combined2 = Compose([net2, shs])
+
+  t.equal(
+    MultiServer([combined1, combined2]).stringify('public'),
+    [combined1.stringify('public'), combined2.stringify('public')].join(';')
+  )
+
+  t.end()
+})
+
+tape('multiple scopes different hosts', function(t) {
+  var net1 = Net({ host: '127.0.0.1', port: 4848, scope: ['local', 'device', 'public']})
+  var net2 = Net({ host: '::1', port: 4847, scope: ['local', 'device', 'public']})
+
+  var combined1 = Compose([net1, shs])
+  var combined2 = Compose([net2, shs])
+
+  t.equal(
+    MultiServer([combined1, combined2]).stringify('public'),
+    [combined1.stringify('public'), combined2.stringify('public')].join(';')
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Previously we were disregarding the `host` setting for all configs
except in cases where `scope === 'public' && `opts.external != null`.
This resolves the error by first checking whether `opts.host` is defined
before falling back to automatic detection methods.

---

Resolves #47 

## Before

```
net:192.168.0.109:8008~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
net:192.168.0.109:8008~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
net:192.168.0.109:8008~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
ws://192.168.0.109:8989~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
ws://192.168.0.109:8989~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
ws://192.168.0.109:8989~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
```

## After

```
net:192.168.0.109:8008~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
net:172.18.0.1:8008~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
net:fce2:9811:4862:81a7:bb08:91d6:2e41:d220:8008~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
ws://192.168.0.109:8989~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
ws://172.18.0.1:8989~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
ws://[fce2:9811:4862:81a7:bb08:91d6:2e41:d220]:8989~shs:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=
```

cc: @dominictarr @arj03 @regular @cryptix @the-kenny