### PR TITLE
fix net plugin to propagate listen() errors up

### DIFF
--- a/plugins/net.js
+++ b/plugins/net.js
@@ -52,7 +52,15 @@ module.exports = ({ scope = 'device', host, port, external, allowHalfOpen, pause
 
       var server = net.createServer(serverOpts, function (stream) {
         onConnection(toDuplex(stream))
-      }).listen(port, host, startedCb)
+      })
+
+      if (startedCb) server.addListener('error', startedCb)
+
+      server.listen(port, host, startedCb ? function () {
+        server.removeListener('error', startedCb)
+        startedCb();
+      } : startedCb)
+
       return function (cb) {
         debug('Closing server on %s:%d', host, port)
         server.close(function(err) {

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -178,6 +178,22 @@ tape('net: do not listen on all addresses', function (t) {
   })
 })
 
+tape('net: do not crash if listen() fails', function(t) {
+  var combined = Compose([
+    Net({
+      scope: 'private',
+      port: 4848,
+      host: '$not-a-valid-ip-addr$',
+    }),
+    shs
+  ])
+  var close = combined.server(echo, function() {}, function(err) {
+    t.ok(err, 'should propagate listen error up')
+    t.equal(err.code, 'ENOTFOUND', 'the error is expected')
+    close(function() {t.end()})
+  })
+})
+
 tape('combined, unix', function (t) {
   var p = 'multiunixtest'+(new Date()).getTime()
   fs.mkdirSync(p)


### PR DESCRIPTION
I get **a lot** of reports that Manyverse is crashing, and the errors look like this:

```
Error: listen EINVAL fe80::c376:4a3f:a128:3466:26831
    at Server.setupListenHandle [as _listen2] (net.js:1269:19)
    at listenInCluster (net.js:1334:12)
    at doListen (net.js:1460:7)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

The correct fix for this error (has to do with suffixing the scope_id e.g. `%wlan0` to the IPv6 address) is not in this PR, but anyway, I found that this error is coming from the `server.listen` call in `multiserver/plugins/net` and was surprised that there was no handling of server errors, so this PR adds that, by simply detecting that error and sending it upwards to the startedCb callback, which can belong to the `combined` multiserver.