### PR TITLE
handle ipv6 addresses suffixed with scope id

### DIFF
--- a/plugins/net.js
+++ b/plugins/net.js
@@ -105,12 +105,15 @@ module.exports = ({ scope = 'device', host, port, external, allowHalfOpen, pause
       // We want to avoid using `host` if the target scope is public and some
       // external host (like example.com) is defined.
       const externalHost = targetScope === 'public' && external
-      const resultHost = externalHost || host || scopes.host(targetScope)
+      let resultHost = externalHost || host || scopes.host(targetScope)
 
       if (resultHost == null) {
         // The device has no network interface for a given `targetScope`.
         return null
       }
+
+      // Remove IPv6 scopeid suffix, if any, e.g. `%wlan0`
+      resultHost = resultHost.replace(/(\%\w+)$/, '')
 
       return toAddress(resultHost, port)
     }

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -128,6 +128,25 @@ tape('combined, ipv6', function (t) {
   })
 })
 
+if (has_ipv6)
+tape('stringify() does not show scopeid from ipv6', function (t) {
+  var combined = Compose([
+    Net({
+      scope: 'private',
+      port: 4848,
+      host: 'fe80::1065:74a4:4016:6266%wlan0'
+    }),
+    shs
+  ])
+  var addr = combined.stringify('private')
+  t.equal(
+    addr,
+    'net:fe80::1065:74a4:4016:6266:4848~shs:' +
+    keys.publicKey.toString('base64')
+  )
+  t.end()
+})
+
 tape('net: do not listen on all addresses', function (t) {
   var combined = Compose([
     Net({
@@ -361,7 +380,7 @@ function testAbort (name, combined) {
         close(function() {t.end()})
       }, 500)
     })
-    
+
     abort()
 
   })


### PR DESCRIPTION
Related to #51, I get a lot of errors that Manyverse is crashing with this:

```
Error: listen EINVAL fe80::c376:4a3f:a128:3466:26831
    at Server.setupListenHandle [as _listen2] (net.js:1269:19)
    at listenInCluster (net.js:1334:12)
    at doListen (net.js:1460:7)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

And it comes from this multiserver's net plugin. After a lot of investigation, I figured out why that IPv6 address is "invalid": all of these IPv6 addresses that I got reports from were all link-local addresses, and given multiple network interfaces on the device, the IPv6 addresses needs a suffix to disambiguate which network interface is that address related to. See [IETF RFC 6874](https://tools.ietf.org/html/rfc6874).

So to fix those kind of crashes, I just need to provide the zone id `%wlan0` or `%en0` (or whatever) as a suffix on the IP address, so if we call `server.listen(port, host)` using the `host` shown below, then the crash is fixed!

```diff
-host = 'fe80::c376:4a3f:a128:3466'
+host = 'fe80::c376:4a3f:a128:3466%wlan0'
```

Read more: https://superuser.com/questions/99746/why-is-there-a-percent-sign-in-the-ipv6-address

> Given the IPv6 Link-Local addressing, where every interface has the same network (fe80::/10), there must be some way to distinguish which specific network is meant when referring to a link-local address. That is what the Scope ID, also called a Zone ID so as not to be confused with the multicast scope flags, is for.

**What this PR does**, however, is to hide the `%wlan0` for remote peers, because the RFC says:

> URIs including a ZoneID are to be interpreted only in the context of the host at which they originate, since the ZoneID is of **local significance only**.

That's why I added some code in `stringify()` to remove the zone ID before sharing it with peers.