### PR TITLE
If key and cert are specified in opts (config), use them to create a https server

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ var Net = require('multiserver/plugins/net')`
 Net({port: 8889, host: 'mydomain.com'}) => net
 net.stringify() => 'net:mydomain.com:8889'
 ```
-### `WebSockets({host,port,scope,handler?})`
+### `WebSockets({host,port,scope,handler?,key?,cert?})`
 
 create a websocket server. Since websockets are
 just a special mode of http, this also creates a http
@@ -239,6 +239,8 @@ WebSockets `ws://{host}:{port}?` port defaults to 80 if not provided.
 
 WebSockets over https is `wss://{host}:{port}?` where port is
 443 if not provided.
+
+If key and cert are provided as paths, a https server will be spawned.
 
 ``` js
 var WebSockets = require('multiserver/plugins/ws`)

--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ WebSockets `ws://{host}:{port}?` port defaults to 80 if not provided.
 WebSockets over https is `wss://{host}:{port}?` where port is
 443 if not provided.
 
-If key and cert are provided as paths, a https server will be spawned.
+If `opts.key` and `opts.cert` are provided as paths, a https server
+will be spawned.
 
 ``` js
 var WebSockets = require('multiserver/plugins/ws`)

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -4,6 +4,8 @@ var pull = require('pull-stream/pull')
 var Map = require('pull-stream/throughs/map')
 var scopes = require('multiserver-scopes')
 var http = require('http')
+var https      = require('https')
+var fs         = require('fs')
 var debug = require('debug')('multiserver:ws')
 
 function safe_origin (origin, address, port) {
@@ -44,7 +46,7 @@ module.exports = function (opts = {}) {
     return s === scope || Array.isArray(scope) && ~scope.indexOf(s)
   }
 
-  var secure = opts.server && !!opts.server.key
+  var secure = opts.server && !!opts.server.key || (!!opts.key && !!opts.cert)
   return {
     name: 'ws',
     scope: () => scope,
@@ -60,7 +62,13 @@ module.exports = function (opts = {}) {
       // the interface is instantiated. Is that the way it should work?
       opts.port = opts.port || getRandomPort()
 
-      var server = opts.server || http.createServer(opts.handler)
+      if (typeof opts.key === 'string')
+        opts.key = fs.readFileSync(opts.key)
+      if (typeof opts.cert === 'string')
+        opts.cert = fs.readFileSync(opts.cert)
+
+      var server = opts.server ||
+          (opts.key && opts.cert ? https.createServer({ key: opts.key, cert: opts.cert }, opts.handler) : http.createServer(opts.handler))
 
       WS.createServer(Object.assign({}, opts, {server: server}), function (stream) {
         stream.address = safe_origin(

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -304,6 +304,18 @@ tape('wss default port', function (t) {
   t.end()
 })
 
+tape('wss with key and cert', function (t) {
+  var ws = Ws({
+    external: 'domain.de',
+    scope: 'public',
+    key: 'path',
+    cert: 'path'
+  })
+  t.equal(ws.stringify('public'), 'wss://domain.de')
+  t.equal(ws.stringify('local'), null)
+  t.equal(ws.stringify('device'), null)
+  t.end()
+})
 
 var onion = Onion({scope: 'public'})
 


### PR DESCRIPTION
So I was trying to set up wss on my pub and found it really hard to get running. Eventually I think its because maybe secret-stack was changed and this hasn't been updated? Anyway this change makes it possible to specify cert and key as paths (in config) and have them loaded. I'm not sure how one is supposed to create a server using just config. This PR doesn't have test which we need for this to be merged, I'm just leaving it here to know if I'm on the right track or if I just havn't found the right configuration options :-)