### PR TITLE
Fix Unix socket on Windows

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -1,11 +1,7 @@
-var assert = require('assert')
 var separator = '~', escape = '!'
 var SE = require('separator-escape')(separator, escape)
 
 var isArray = Array.isArray
-function isFunction (f) {
-  return 'function' === typeof f
-}
 function isString (s) {
   return 'string' === typeof s
 }

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ module.exports = function (plugs, wrap) {
   var _self = {
     name: plugs.map(function (e) { return e.name }).join(';'),
     client: function (addr, cb) {
-      var _addr = split(addr).find(function (addr) {
+      let plug
+      const _addr = split(addr).find(function (addr) {
         //connect with the first plug that understands this string.
         plug = plugs.find(function (plug) {
           return plug.parse(addr) ? plug : null

--- a/package.json
+++ b/package.json
@@ -10,18 +10,15 @@
   "dependencies": {
     "debug": "^4.1.1",
     "multicb": "^1.2.2",
-    "multiserver-scopes": "^1.0.0",
-    "pull-cat": "~1.1.5",
     "pull-stream": "^3.6.1",
     "pull-ws": "^3.3.0",
     "secret-handshake": "^1.1.16",
-    "separator-escape": "0.0.0",
+    "separator-escape": "0.0.1",
     "socks": "^2.2.3",
     "stream-to-pull-stream": "^1.7.2"
   },
   "devDependencies": {
     "chloride": "^2.2.8",
-    "pull-file": "^0.5.0",
     "pull-pushable": "^2.2.0",
     "tape": "^4.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "multicb": "^1.2.2",
+    "multiserver-scopes": "^1.0.0",
     "pull-stream": "^3.6.1",
     "pull-ws": "^3.3.0",
     "secret-handshake": "^1.1.16",

--- a/plugins/noauth.js
+++ b/plugins/noauth.js
@@ -1,5 +1,3 @@
-var pull = require('pull-stream')
-
 module.exports = function (opts) {
   return {
     name: 'noauth',

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -31,7 +31,7 @@ module.exports = function (opts) {
       cb(new Error("Use net plugin for onion server instead"))
     },
     client: function (opts, cb) {
-      var started = false, _socket, destroy
+      var _socket, destroy
 
       function tryConnect(connectOpts, onFail) {
         socks.createConnection(connectOpts, function(err, result) {

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -3,12 +3,14 @@ var net = require('net')
 var fs = require('fs')
 var path = require('path')
 var debug = require('debug')('multiserver:unix')
+const os = require('os')
 
 // hax on double transform
 var started = false
 
 module.exports = function (opts) {
-  const socket = path.join(opts.path || '', 'socket')
+  opts.path = opts.path ||  fs.mkdtempSync(path.join(os.tmpdir(), 'multiserver-'))
+  const socket = path.join(opts.path, 'socket')
   const addr = 'unix:' + socket
   let scope = opts.scope || 'device'
   opts = opts || {}

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -9,11 +9,11 @@ const os = require('os')
 var started = false
 
 module.exports = function (opts) {
-	if (process.platform === 'win32') {
-		opts.path = opts.path || path.join('\\\\?\\pipe', process.cwd(), 'multiserver')
-	} else {
-		opts.path = opts.path ||  fs.mkdtempSync(path.join(os.tmpdir(), 'multiserver-'))
-	}
+  if (process.platform === 'win32') {
+    opts.path = opts.path || path.join('\\\\?\\pipe', process.cwd(), 'multiserver')
+  } else {
+    opts.path = opts.path ||  fs.mkdtempSync(path.join(os.tmpdir(), 'multiserver-'))
+  }
 
   const socket = path.join(opts.path, 'socket')
   const addr = 'unix:' + socket

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -9,7 +9,12 @@ const os = require('os')
 var started = false
 
 module.exports = function (opts) {
-  opts.path = opts.path ||  fs.mkdtempSync(path.join(os.tmpdir(), 'multiserver-'))
+	if (process.platform === 'win32') {
+		opts.path = opts.path || path.join('\\\\?\\pipe', process.cwd(), 'multiserver')
+	} else {
+		opts.path = opts.path ||  fs.mkdtempSync(path.join(os.tmpdir(), 'multiserver-'))
+	}
+
   const socket = path.join(opts.path, 'socket')
   const addr = 'unix:' + socket
   let scope = opts.scope || 'device'
@@ -89,11 +94,16 @@ module.exports = function (opts) {
     //MUST be unix:socket_path
     parse: function (s) {
       var ary = s.split(':')
+
+      // Immediately return if there's no path.
       if(ary.length < 2) return null
+
+      // Immediately return if the first item isn't 'unix'.
       if('unix' !== ary.shift()) return null
+
       return {
         name: '',
-        path: ary.shift()
+        path: ary.join(':')
       }
     },
     stringify: function (_scope) {

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -48,7 +48,9 @@ module.exports = function (opts) {
       })
 
       if (process.platform !== 'win32') {
-        fs.chmodSync(socket, 0600)
+        // mode is set to allow read and write
+        const mode = fs.constants.S_IRUSR + fs.constants.S_IWUSR
+        fs.chmodSync(socket, mode)
       }
 
       started = true

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -68,7 +68,7 @@ module.exports = function (opts = {}) {
         opts.cert = fs.readFileSync(opts.cert)
 
       var server = opts.server ||
-          (opts.key && opts.cert ? https.createServer({ key: opts.key, cert: opts.cert }, opts.handler) : http.createServer(opts.handler))
+        (opts.key && opts.cert ? https.createServer({ key: opts.key, cert: opts.cert }, opts.handler) : http.createServer(opts.handler))
 
       WS.createServer(Object.assign({}, opts, {server: server}), function (stream) {
         stream.address = safe_origin(

--- a/test/multi.js
+++ b/test/multi.js
@@ -1,20 +1,16 @@
 var tape = require('tape')
 var pull = require('pull-stream')
-var Pushable = require('pull-pushable')
 
 var Compose = require('../compose')
 var Net = require('../plugins/net')
 var Ws = require('../plugins/ws')
 var Shs = require('../plugins/shs')
-var Onion = require('../plugins/onion')
 var MultiServer = require('../')
 
 var cl = require('chloride')
 var seed = cl.crypto_hash_sha256(Buffer.from('TESTSEED'))
 var keys = cl.crypto_sign_seed_keypair(seed)
 var appKey = cl.crypto_hash_sha256(Buffer.from('TEST'))
-
-var requested, ts
 
 //this gets overwritten in the last test.
 var check = function (id, cb) {
@@ -25,9 +21,6 @@ var net = Net({port: 4848, scope: 'device'})
 var ws = Ws({port: 4849, scope: 'device'})
 console.log('appKey', appKey)
 var shs = Shs({keys: keys, appKey: appKey, auth: function (id, cb) {
-  requested = id
-  ts = Date.now()
-
   check(id, cb)
 }})
 

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -188,12 +188,9 @@ tape('net: do not crash if listen() fails', function(t) {
 })
 
 tape('combined, unix', function (t) {
-  var p = 'multiunixtest'+(new Date()).getTime()
-  fs.mkdirSync(p)
   var combined = Compose([
     Unix({
       server: true,
-      path: p,
     }),
     shs
   ])
@@ -211,7 +208,6 @@ tape('combined, unix', function (t) {
         if(err) throw err
         t.equal(Buffer.concat(ary).toString(), 'HELLO WORLD')
         close(function() {
-          fs.rmdirSync(p)
           t.end()
         })
       })

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -1,8 +1,7 @@
-var fs = require('fs')
 var tape = require('tape')
 var pull = require('pull-stream')
 var Pushable = require('pull-pushable')
-var scopes = require('multiserver-scopes')
+const fs = require('fs')
 
 var Compose = require('../compose')
 var Net = require('../plugins/net')
@@ -17,20 +16,14 @@ var seed = cl.crypto_hash_sha256(Buffer.from('TESTSEED'))
 var keys = cl.crypto_sign_seed_keypair(seed)
 var appKey = cl.crypto_hash_sha256(Buffer.from('TEST'))
 
-var requested, ts
-
 //this gets overwritten in the last test.
 var check = function (id, cb) {
   cb(null, true)
 }
 
-//var net = Net({port: 4848, scope: 'device'})
 var net = Net({port: 4848})
 var ws = Ws({port: 4848})
 var shs = Shs({keys: keys, appKey: appKey, auth: function (id, cb) {
-  requested = id
-  ts = Date.now()
-
   check(id, cb)
 }})
 
@@ -425,9 +418,8 @@ tape('error should have client address on it', function (t) {
   var close = combined.server(function (stream) {
     throw new Error('should never happen')
   }, function (err) {
-    var addr = err.address
-    t.ok(/^net\:/.test(err.address))
-    t.ok(/\~shs\:/.test(err.address))
+    t.ok(/^net:/.test(err.address))
+    t.ok(/~shs:/.test(err.address))
     //the shs address won't actually parse, because it doesn't have the key in it
     //because the key is not known in a wrong number.
   }, function () {

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -93,52 +93,52 @@ tape('combined', function (t) {
 })
 
 if (has_ipv6)
-tape('combined, ipv6', function (t) {
-  var combined = Compose([
-    Net({
-      port: 4848,
-      host: '::'
-    }),
-    shs
-  ])
-  var close = combined.server(echo)
-  var addr = combined.stringify('device')
-  console.log('addr', addr)
+  tape('combined, ipv6', function (t) {
+    var combined = Compose([
+      Net({
+        port: 4848,
+        host: '::'
+      }),
+      shs
+    ])
+    var close = combined.server(echo)
+    var addr = combined.stringify('device')
+    console.log('addr', addr)
 
 
-  combined.client(addr, function (err, stream) {
-    if(err) throw err
-    t.ok(stream.address, 'has an address')
-    pull(
-      pull.values([Buffer.from('hello world')]),
-      stream,
-      pull.collect(function (err, ary) {
-        if(err) throw err
-        t.equal(Buffer.concat(ary).toString(), 'HELLO WORLD')
-        close(function() {t.end()})
-      })
-    )
+    combined.client(addr, function (err, stream) {
+      if(err) throw err
+      t.ok(stream.address, 'has an address')
+      pull(
+        pull.values([Buffer.from('hello world')]),
+        stream,
+        pull.collect(function (err, ary) {
+          if(err) throw err
+          t.equal(Buffer.concat(ary).toString(), 'HELLO WORLD')
+          close(function() {t.end()})
+        })
+      )
+    })
   })
-})
 
 if (has_ipv6)
-tape('stringify() does not show scopeid from ipv6', function (t) {
-  var combined = Compose([
-    Net({
-      scope: 'private',
-      port: 4848,
-      host: 'fe80::1065:74a4:4016:6266%wlan0'
-    }),
-    shs
-  ])
-  var addr = combined.stringify('private')
-  t.equal(
-    addr,
-    'net:fe80::1065:74a4:4016:6266:4848~shs:' +
-    keys.publicKey.toString('base64')
-  )
-  t.end()
-})
+  tape('stringify() does not show scopeid from ipv6', function (t) {
+    var combined = Compose([
+      Net({
+        scope: 'private',
+        port: 4848,
+        host: 'fe80::1065:74a4:4016:6266%wlan0'
+      }),
+      shs
+    ])
+    var addr = combined.stringify('private')
+    t.equal(
+      addr,
+      'net:fe80::1065:74a4:4016:6266:4848~shs:' +
+      keys.publicKey.toString('base64')
+    )
+    t.end()
+  })
 
 tape('net: do not listen on all addresses', function (t) {
   var combined = Compose([
@@ -146,7 +146,7 @@ tape('net: do not listen on all addresses', function (t) {
       scope: 'device',
       port: 4848,
       host: 'localhost',
-//      external: scopes.host('private') // unroutable IP, but not localhost (e.g. 192.168 ...)
+      //      external: scopes.host('private') // unroutable IP, but not localhost (e.g. 192.168 ...)
     }),
     shs
   ])
@@ -158,7 +158,7 @@ tape('net: do not listen on all addresses', function (t) {
       scope: 'local',
       port: 4848,
       //host: 'localhost',
-//      external: scopes.host('local') // unroutable IP, but not localhost (e.g. 192.168 ...)
+      //      external: scopes.host('local') // unroutable IP, but not localhost (e.g. 192.168 ...)
     }),
     shs
   ])
@@ -411,7 +411,7 @@ testAbort('combined', combined)
 testAbort('combined.ws', combined_ws)
 
 tape('error should have client address on it', function (t) {
-//  return t.end()
+  //  return t.end()
   check = function (id, cb) {
     throw new Error('should never happen')
   }


### PR DESCRIPTION
I've cherry-picked some commits from #49 into this branch to try to separate the changes that I've made. There *are* some unrelated improvements in these commits, like removing unused variables, but this branch should be mostly focused on fixing the unix-socket plugin on Windows.

Roughly, these changes include:

- Use the correct path to the Unix socket on Windows.
- Use a temporary directory on all platforms if `opts.path` is unset.
- Replace octal `chmod 0600` with Node.js permission constants
  - Now this module can be parsed in strict mode!
- Remove hardcoded path from tests so they run on all platforms.

Please note that this does *not* fix the build on macOS, because that would require that we're correctly `stringify()`ing multiserver addresses (and that was left in the other branch).